### PR TITLE
FIX issue #219

### DIFF
--- a/src/views/authentication/ScopesPane/index.tsx
+++ b/src/views/authentication/ScopesPane/index.tsx
@@ -55,7 +55,7 @@ export function ScopePane() {
 			}
 
 			if (editingSignup) {
-				query += ` SIGNIN ${openSymbol + editingSignup + closeSymbol}`;
+				query += ` SIGNUP ${openSymbol + editingSignup + closeSymbol}`;
 			}
 
 			await executeQuery(query);


### PR DESCRIPTION
There was a typo in scope pane view that sends `SIGNIN` twice instead `SIGNUP`