### PR TITLE
Customize query view orientation

### DIFF
--- a/src/adapter/mini.tsx
+++ b/src/adapter/mini.tsx
@@ -1,6 +1,6 @@
-import { DATASETS, SANDBOX } from "~/constants";
+import { DATASETS, ORIENTATIONS, SANDBOX } from "~/constants";
 import { BrowserAdapter } from "./browser";
-import { SurrealistConfig } from "~/types";
+import { Orientation, SurrealistConfig } from "~/types";
 import { createBaseSettings, createBaseTab, createSandboxConnection } from "~/util/defaults";
 import { showError } from "~/util/helpers";
 import { executeQuery } from "~/connection";
@@ -25,7 +25,8 @@ export class MiniAdapter extends BrowserAdapter {
 			dataset,
 			setup,
 			theme,
-			compact
+			compact,
+			orientation,
 		} = Object.fromEntries(params.entries());
 
 		// Hide titlebar
@@ -79,6 +80,18 @@ export class MiniAdapter extends BrowserAdapter {
 				title: 'Startup error',
 				subtitle: 'Theme not recognised'
 			});
+		}
+
+		// Orientation
+		if (orientation) {
+			if (ORIENTATIONS.some(o => o.value === orientation)) {
+				settings.appearance.queryOrientation = orientation as Orientation;
+			} else {
+				showError({
+					title: 'Startup error',
+					subtitle: 'Orientation not recognised'
+				});
+			}
 		}
 
 		return {

--- a/src/components/Pane/index.tsx
+++ b/src/components/Pane/index.tsx
@@ -46,6 +46,7 @@ export function ContentPane({
 							fw={600}
 							c="bright"
 							className={classes.title}
+							style={{ flexShrink: 0 }}
 						>
 							{title}
 						</Text>

--- a/src/components/Scaffold/settings/tabs/Appearance.tsx
+++ b/src/components/Scaffold/settings/tabs/Appearance.tsx
@@ -2,7 +2,7 @@ import { Select, Slider, Box, Checkbox } from "@mantine/core";
 import { useCheckbox } from "~/hooks/events";
 import { isDesktop } from "~/adapter";
 import { Label, SettingsSection } from "../utilities";
-import { DESIGNER_DIRECTIONS, DESIGNER_NODE_MODES, VALUE_MODES, RESULT_MODES, THEMES } from "~/constants";
+import { DESIGNER_DIRECTIONS, DESIGNER_NODE_MODES, VALUE_MODES, RESULT_MODES, THEMES, ORIENTATIONS } from "~/constants";
 import { useSetting } from "~/hooks/config";
 import { useFeatureFlags } from "~/util/feature-flags";
 
@@ -14,6 +14,7 @@ export function AppearanceTab() {
 	const [windowScale, setWindowScale] = useSetting(CAT, "windowScale");
 	const [resultWordWrap, setResultWordWrap] = useSetting(CAT, "resultWordWrap");
 	const [defaultResultMode, setDefaultResultMode] = useSetting(CAT, "defaultResultMode");
+	const [queryOrientation, setQueryOrientation] = useSetting(CAT, "queryOrientation");
 	const [valueMode, setValueMode] = useSetting(CAT, "valueMode");
 	const [defaultDiagramMode, setDefaultDiagramMode] = useSetting(CAT, "defaultDiagramMode");
 	const [defaultDiagramDirection, setDefaultDiagramDirection] = useSetting(CAT, "defaultDiagramDirection");
@@ -107,6 +108,13 @@ export function AppearanceTab() {
 					data={RESULT_MODES}
 					value={defaultResultMode}
 					onChange={setDefaultResultMode as any}
+				/>
+
+				<Select
+					label="Layout orientation"
+					data={ORIENTATIONS}
+					value={queryOrientation}
+					onChange={setQueryOrientation as any}
 				/>
 			</SettingsSection>
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -3,6 +3,7 @@ import explorerIcon from "~/assets/animation/explorer.json";
 import designerIcon from "~/assets/animation/designer.json";
 import authIcon from "~/assets/animation/auth.json";
 
+import { getConnection } from "./util/connection";
 import {
 	AuthMode,
 	CodeLang,
@@ -13,6 +14,7 @@ import {
 	Selectable,
 	ViewInfo,
 	ViewMode,
+	Orientation,
 } from "./types";
 import {
 	iconAPI,
@@ -26,7 +28,6 @@ import {
 	iconModel,
 	iconQuery,
 } from "./util/icons";
-import { getConnection } from "./util/connection";
 
 export type StructureTab = "graph" | "builder";
 export type ExportType = (typeof EXPORT_TYPES)[number];
@@ -206,4 +207,9 @@ export const SURQL_FILTERS = [
 		name: "SurrealDB Schema",
 		extensions: ["surql", "sql", "surrealql"],
 	},
+];
+
+export const ORIENTATIONS: Selectable<Orientation>[] = [
+	{ label: "Horizontal", value: "horizontal" },
+	{ label: "Vertical", value: "vertical" },
 ];

--- a/src/mini/new.tsx
+++ b/src/mini/new.tsx
@@ -3,14 +3,15 @@ import "../assets/styles/embed-new.scss";
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { createRoot } from "react-dom/client";
-import { DATASETS } from "~/constants";
+import { DATASETS, ORIENTATIONS } from "~/constants";
+import { Orientation } from "~/types";
 
-type Theme = keyof typeof themes;
-const themes = {
-	auto: "Automatic",
-	light: "Light",
-	dark: "Dark"
-};
+// type Theme = keyof typeof themes;
+// const themes = {
+// 	auto: "Automatic",
+// 	light: "Light",
+// 	dark: "Dark"
+// };
 
 const datasets = {
 	"none": "None",
@@ -23,7 +24,8 @@ function App() {
 	const [setup, setSetup] = useState<string>(defaults.setup);
 	const [query, setQuery] = useState<string>(defaults.query);
 	const [variables, setVariables] = useState<string>(defaults.variables);
-	const [theme, setTheme] = useState<Theme>(defaults.theme);
+	// const [theme, setTheme] = useState<Theme>(defaults.theme);
+	const [orientation, setOrientation] = useState<Orientation>("vertical");
 	const [copied, onCopy] = useBoomerang(false);
 
 	const url = useMemo(() => {
@@ -33,14 +35,15 @@ function App() {
 		if (setup && setup.length > 0) search.append('setup', setup);
 		if (query && query.length > 0) search.append('query', query);
 		if (Object.keys(variables).length > 0) search.append('variables', variables);
-		if (theme !== 'auto') search.append('theme', theme);
+		if (orientation !== 'vertical') search.append('orientation', orientation);
+		// if (theme !== 'auto') search.append('theme', theme);
 
 		const url = new URL(location.toString());
 		url.pathname = url.hostname == 'localhost' ? 'mini/run.html' : 'mini';
 		url.search = search.toString();
 
 		return url.toString();
-	}, [dataset, setup, query, variables, theme]);
+	}, [dataset, setup, query, variables, orientation, /*theme*/]);
 
 	const [delayedUrl, countdown, setDelayedUrl] = useDelayedValue(url);
 	const reloadIframe = useCallback(() => {
@@ -55,7 +58,8 @@ function App() {
 			setSetup(params.setup);
 			setQuery(params.query);
 			setVariables(params.variables);
-			setTheme(params.theme);
+			setOrientation(params.orientation);
+			// setTheme(params.theme);
 		} catch(_err) {
 			(_err);
 			alert("Invalid URL pasted");
@@ -67,7 +71,7 @@ function App() {
 		setSetup("");
 		setQuery("");
 		setVariables("");
-		setTheme("auto");
+		// setTheme("auto");
 		reloadIframe();
 	}, []);
 
@@ -141,6 +145,20 @@ function App() {
 					</div>
 
 					<div className="section">
+						<label htmlFor="theme">Orientation</label>
+						<select
+							name="theme"
+							id="theme"
+							value={orientation}
+							onInput={(e) => setOrientation(e.currentTarget.value as Orientation)}
+						>
+							{ORIENTATIONS.map(({ label, value }) => (
+								<option key={value} value={value}>{label}</option>
+							))}
+						</select>
+					</div>
+
+					{/* <div className="section">
 						<label htmlFor="theme">Theme</label>
 						<select
 							name="theme"
@@ -152,7 +170,7 @@ function App() {
 								<option key={key} value={key}>{value}</option>
 							))}
 						</select>
-					</div>
+					</div> */}
 				</form>
 				<div className="preview">
 					<div className="title-button">
@@ -202,13 +220,15 @@ function processUrl(input: string) {
 		setup: setup ? setup.toString() : '',
 		query: query ? query.toString() : '',
 		variables: Object.keys(parsedVariables).length > 0 ? JSON.stringify(parsedVariables, null, 4) : '',
-		theme: Object.keys(themes).includes(theme) ? theme : 'auto'
+		orientation: url.searchParams.get('orientation') as Orientation || 'vertical',
+		// theme: Object.keys(themes).includes(theme) ? theme : 'auto'
 	} as {
 		dataset: string;
 		setup: string;
 		query: string;
 		variables: string;
-		theme: Theme;
+		orientation: Orientation;
+		// theme: Theme;
 	};
 }
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,6 +1,17 @@
 import { MantineColorScheme } from "@mantine/core";
 import { FeatureFlagMap } from "./util/feature-flags";
 
+export type DriverType = "file" | "memory" | "tikv";
+export type ResultMode = "table" | "single" | "combined" | "live";
+export type SourceMode = "schema" | "infer";
+export type DiagramMode = "fields" | "summary" | "simple";
+export type DiagramDirection = "ltr" | "rtl";
+export type ColorScheme = "light" | "dark";
+export type Platform = "darwin" | "windows" | "linux";
+export type TableType = "ANY" | "NORMAL" | "RELATION";
+export type ValueMode = "json" | "sql";
+export type Orientation = "horizontal" | "vertical";
+export type Protocol = "http" | "https" | "ws" | "wss" | "mem" | "indxdb";
 export type AuthMode =
 	| "none"
 	| "root"
@@ -9,8 +20,6 @@ export type AuthMode =
 	| "token"
 	| "scope"
 	| "scope-signup";
-export type DriverType = "file" | "memory" | "tikv";
-export type ResultMode = "table" | "single" | "combined" | "live";
 export type ViewMode =
 	| "query"
 	| "explorer"
@@ -19,11 +28,6 @@ export type ViewMode =
 	| "functions"
 	| "models"
 	| "documentation";
-export type SourceMode = "schema" | "infer";
-export type DiagramMode = "fields" | "summary" | "simple";
-export type DiagramDirection = "ltr" | "rtl";
-export type ColorScheme = "light" | "dark";
-export type Protocol = "http" | "https" | "ws" | "wss" | "mem" | "indxdb";
 export type CodeLang =
 	| "cli"
 	| "rust"
@@ -33,9 +37,6 @@ export type CodeLang =
 	| "csharp"
 	| "java"
 	| "php";
-export type Platform = "darwin" | "windows" | "linux";
-export type TableType = "ANY" | "NORMAL" | "RELATION";
-export type ValueMode = "json" | "sql";
 
 export type OpenFn = (id: string | null) => void;
 export type ColumnSort = [string, "asc" | "desc"];
@@ -98,6 +99,7 @@ export interface SurrealistAppearanceSettings {
 	defaultDiagramDirection: DiagramDirection;
 	expandSidebar: boolean;
 	valueMode: ValueMode;
+	queryOrientation: Orientation;
 }
 
 export interface SurrealistTemplateSettings {

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -45,6 +45,7 @@ export function createBaseSettings(): SurrealistSettings {
 			defaultDiagramDirection: "ltr",
 			expandSidebar: true,
 			valueMode: "sql",
+			queryOrientation: "vertical"
 		},
 		templates: {
 			list: []

--- a/src/views/query/QueryView/index.tsx
+++ b/src/views/query/QueryView/index.tsx
@@ -32,6 +32,7 @@ import { InPortal, createHtmlPortalNode } from "react-reverse-portal";
 import { SelectionRange } from "@codemirror/state";
 import { useIntent } from "~/hooks/url";
 import { executeUserQuery } from "~/connection";
+import { useSetting } from "~/hooks/config";
 
 const switchPortal = createHtmlPortalNode();
 
@@ -39,6 +40,7 @@ export function QueryView() {
 	const { saveQuery } = useConfigStore.getState();
 	const isLight = useIsLight();
 
+	const [orientation] = useSetting("appearance", "queryOrientation");
 	const [showVariables, showVariablesHandle] = useBoolean();
 	const [variablesValid, setVariablesValid] = useState(true);
 	const [queryValid, setQueryValid] = useState(true);
@@ -108,6 +110,10 @@ export function QueryView() {
 		});
 	});
 
+	const variablesOrientation = orientation === "horizontal"
+		? "vertical"
+		: "horizontal";
+
 	useIntent("open-saved-queries", showSavedHandle.open);
 	useIntent("open-query-history", showHistoryHandle.open);
 	useIntent("run-query", runQuery);
@@ -156,8 +162,8 @@ export function QueryView() {
 					/>
 				)}
 				{active && (
-					<PanelGroup direction="vertical">
-						<Panel minSize={25}>
+					<PanelGroup direction={orientation}>
+						<Panel minSize={35}>
 							{isMini ? (showVariables ? (
 								<VariablesPane
 									isValid={variablesValid}
@@ -176,8 +182,8 @@ export function QueryView() {
 									onSelectionChange={setSelection}
 								/>
 							)) : (
-								<PanelGroup direction="horizontal">
-									<Panel minSize={25}>
+								<PanelGroup direction={variablesOrientation}>
+									<Panel minSize={35}>
 										<QueryPane
 											activeTab={active}
 											setIsValid={setQueryValid}
@@ -190,7 +196,7 @@ export function QueryView() {
 									{showVariables && (
 										<>
 											<PanelDragger />
-											<Panel defaultSize={40} minSize={25}>
+											<Panel defaultSize={40} minSize={35}>
 												<VariablesPane
 													isValid={variablesValid}
 													setIsValid={setVariablesValid}
@@ -203,7 +209,7 @@ export function QueryView() {
 							)}
 						</Panel>
 						<PanelDragger />
-						<Panel minSize={25}>
+						<Panel minSize={35}>
 							<ResultPane
 								activeTab={active}
 								isQueryValid={queryValid}

--- a/src/views/query/ResultPane/index.tsx
+++ b/src/views/query/ResultPane/index.tsx
@@ -1,3 +1,4 @@
+import classes from "./style.module.scss";
 import { Box, Button, Center, Divider, Group, Pagination, Select, Stack, Text } from "@mantine/core";
 import { useIsLight } from "~/hooks/theme";
 import { useState } from "react";
@@ -98,7 +99,7 @@ export function ResultPane({
 			title={panelTitle}
 			icon={iconQuery}
 			rightSection={
-				<Group align="center">
+				<Group align="center" wrap="nowrap" className={classes.controls}>
 					{resultMode == "live" ? (isLive && (
 						<Button
 							onClick={cancelQueries}
@@ -112,7 +113,10 @@ export function ResultPane({
 							Stop listening
 						</Button>
 					)) : (
-						<Text c={isLight ? "slate.5" : "slate.2"}>
+						<Text
+							c={isLight ? "slate.5" : "slate.2"}
+							className={classes.results}
+						>
 							{statusText}
 						</Text>
 					)}
@@ -140,6 +144,7 @@ export function ResultPane({
 						color={isQueryValid ? "surreal" : "pink.9"}
 						variant={isQueryValid ? "gradient" : "filled"}
 						style={{ border: "none" }}
+						className={classes.run}
 						rightSection={
 							<Icon path={iconCursor} />
 						}

--- a/src/views/query/ResultPane/index.tsx
+++ b/src/views/query/ResultPane/index.tsx
@@ -1,5 +1,5 @@
 import classes from "./style.module.scss";
-import { Box, Button, Center, Divider, Group, Pagination, Select, Stack, Text } from "@mantine/core";
+import { ActionIcon, Box, Button, Center, Divider, Group, Menu, Pagination, Stack, Text, Tooltip } from "@mantine/core";
 import { useIsLight } from "~/hooks/theme";
 import { useState } from "react";
 import { useLayoutEffect } from "react";
@@ -12,10 +12,11 @@ import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
 import { QueryResponse, ResultMode, TabQuery } from "~/types";
 import { useStable } from "~/hooks/stable";
-import { iconBroadcastOff, iconCursor, iconHelp, iconQuery } from "~/util/icons";
+import { iconBroadcastOff, iconCursor, iconQuery } from "~/util/icons";
 import { SelectionRange } from "@codemirror/state";
 import { cancelLiveQueries } from "~/connection";
 import { useDatabaseStore } from "~/stores/database";
+import { isMini } from "~/adapter";
 
 function computeRowCount(response: QueryResponse) {
 	if (!response) {
@@ -79,7 +80,7 @@ export function ResultPane({
 		setResultTab(1);
 	}, [responses.length]);
 
-	const modeIcon = RESULT_MODES.find(r => r.value == resultMode)?.icon ?? iconHelp;
+	const activeMode = RESULT_MODES.find(r => r.value == resultMode)!;
 	const hasSelection = selection?.empty === false;
 
 	const statusText = (showResponses
@@ -121,21 +122,42 @@ export function ResultPane({
 						</Text>
 					)}
 
-					<Select
-						data={RESULT_MODES}
-						value={resultMode}
-						onChange={setResultMode as any}
-						w={130}
-						styles={{
-							input: {
-								height: 34,
-								minHeight: 0
-							}
-						}}
-						leftSection={
-							<Icon path={modeIcon} />
-						}
-					/>
+					<Menu>
+						<Menu.Target>
+							{isMini ? (
+								<Tooltip label="Click to change mode">
+									<ActionIcon
+										aria-label={`Change result mode. Currently ${activeMode}`}
+										h={30}
+										w={30}
+									>
+										<Icon path={activeMode.icon} />
+									</ActionIcon>
+								</Tooltip>
+							) : (
+								<Button
+									size="xs"
+									radius="xs"
+									aria-label="Change result mode"
+									color="slate"
+									leftSection={<Icon path={activeMode.icon} />}
+								>
+									{activeMode.label}
+								</Button>
+							)}
+						</Menu.Target>
+						<Menu.Dropdown>
+							{RESULT_MODES.map(({ label, value, icon }) => (
+								<Menu.Item
+									key={value}
+									onClick={() => setResultMode(value)}
+									leftSection={<Icon path={icon} />}
+								>
+									{label}
+								</Menu.Item>
+							))}
+						</Menu.Dropdown>
+					</Menu>
 
 					<Button
 						size="xs"

--- a/src/views/query/ResultPane/style.module.scss
+++ b/src/views/query/ResultPane/style.module.scss
@@ -1,0 +1,25 @@
+.controls {
+	container-type: size;
+	justify-content: right;
+	width: 100%;
+}
+
+@container (width < 375px) {
+	.results {
+		display: none;
+	}
+}
+
+@container (width < 250px) {
+	.run {
+		padding-inline: 10px;
+		
+		:global(.mantine-Button-label) {
+			display: none;
+		}
+
+		:global(.mantine-Button-section) {
+			margin: 0;
+		}
+	}
+}

--- a/src/views/query/ResultPane/style.module.scss
+++ b/src/views/query/ResultPane/style.module.scss
@@ -4,13 +4,13 @@
 	width: 100%;
 }
 
-@container (width < 375px) {
+@container (width < 325px) {
 	.results {
 		display: none;
 	}
 }
 
-@container (width < 250px) {
+@container (width < 225px) {
 	.run {
 		padding-inline: 10px;
 		


### PR DESCRIPTION
This PR introduces a new setting which allows customising the orientation of the query view. Most importantly, this allows for displaying queries and results side-by-side similar to Surrealist 1.x.

## Preview
<img width="1409" alt="image" src="https://github.com/surrealdb/surrealist/assets/7606171/5190a284-299c-4cdf-b7e5-a6cdd9ab7045">
