### PR TITLE
Automated publishing to the AUR

### DIFF
--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -113,3 +113,33 @@ jobs:
             aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
         - name: Distribute across regions
           run: aws s3 sync --delete --exact-timestamp --source-region eu-west-2 --region ${{ matrix.region }} s3://www.surrealist.app s3://www.${{ matrix.region }}.surrealist.app
+
+    publish_aur_package:
+          name: Publish to AUR package
+          if: ${{ !github.event.release.prerelease }}
+          needs:
+            - version
+
+          runs-on: 'ubuntu-latest'
+          steps:
+            - name: Information
+              run: echo "Publishing surrealist-bin version ${{ needs.version.outputs.version }}"
+
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Generate PKGBUILD
+              run: python ci/generate-pkgbuild.py
+              env:
+                PKGVER: ${{ needs.version.outputs.version }}
+                PKGREL: 1
+
+            - name: Publish surrealist-bin to the AUR
+              uses: KSXGitHub/github-actions-deploy-aur@v2.7.1
+              with:
+                pkgname: surrealist-bin
+                pkgbuild: PKGBUILD
+                commit_username: GitHub Actions
+                commit_email: action@github.com
+                ssh_private_key: ${{ secrets.AUR_PRIVATE_KEY }}
+                commit_message: ${{ needs.version.outputs.version }}

--- a/ci/generate-pkgbuild.py
+++ b/ci/generate-pkgbuild.py
@@ -1,0 +1,37 @@
+from os import environ
+
+pkgver = environ.get('PKGVER')
+if not pkgver:
+  print('PKGVER is required but missing')
+  exit(1)
+
+pkgrel = environ.get('PKGREL')
+if not pkgrel:
+  print('PKGREL is required but missing')
+  exit(1)
+
+pkgbuild_content = f"""# Maintainer: tacheometrist <aur@tacheometrist.dev>
+
+pkgname=surrealist-bin
+pkgver={pkgver}
+pkgrel={pkgrel}
+""" + """pkgdesc="Surrealist is the ultimate way to visually manage your SurrealDB database"
+arch=("x86_64")
+url="https://surrealdb.com/docs/surrealist"
+license=("MIT")
+groups=()
+depends=("webkit2gtk" "gtk3" "openssl-1.1")
+provides=("surrealist")
+conflicts=("surrealist")
+source=("https://github.com/surrealdb/surrealist/releases/download/surrealist-v${pkgver//_/-}/surrealist_${pkgver//_/-}_amd64.deb")
+md5sums=("SKIP")
+
+package() {
+	bsdtar -O -xf "surrealist_${pkgver//_/-}_amd64.deb" data.tar.gz | bsdtar -C "${pkgdir}" -xJf -
+	sed -i 's/Exec=surrealist/Exec=env WEBKIT_DISABLE_DMABUF_RENDERER=1 surrealist/g' ${pkgdir}/usr/share/applications/surrealist.desktop
+	echo "Comment=Surrealist is the ultimate way to visually manage your SurrealDB database" >> ${pkgdir}/usr/share/applications/surrealist.desktop
+}
+"""
+
+with open('PKGBUILD', 'w') as pkgbuild:
+  pkgbuild.write(pkgbuild_content)


### PR DESCRIPTION
At the moment, I'm updating the [surrealist-bin](https://aur.archlinux.org/packages/surrealist-bin) package on the Arch User Repository manually, but this can be automated, and ownership can be given to the SurrealDB developers.

The way the AUR package works right now is by extracting from the released `.deb` packages - since they're just Linux executables, running `surrealist` or opening it from the `.desktop` app works without issue.*

I've added a step to the GitHub `push-release.yaml` workflow, which I've tested locally, end to end using [act](https://github.com/nektos/act) - it's working and publishing correctly if supplying it with my private SSH key in the `AUR_PRIVATE_KEY` secret. Here's one change it commited: https://aur.archlinux.org/cgit/aur.git/commit/?h=surrealist-bin&id=681d6803d978f3517e06fbdae647a092d3f7d6ca

The build step does need to use a separate script to generate the package definition (called PKGBUILD) in `ci/generate-pkgbuild.py`, but this can be moved to another directory if needed. I've followed the examples from the docs of the [Publish AUR Package](https://github.com/marketplace/actions/publish-aur-package) action which is being used.

Let me know what you think 👍 

*Note: If running `surrealist` from the CLI, an environment variable must be set for the window to display properly, `WEBKIT_DISABLE_DMABUF_RENDERER=1` because of an upstream issue with webkit2gtk on Nvidia GPUs. This isn't an issue if opening from the desktop entry, as the environment variable is already set.