### PR TITLE
feat: Add vim mode to query editor and settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"@mantine/notifications": "^7.6.2",
 		"@mdi/js": "^7.2.96",
 		"@replit/codemirror-indentation-markers": "^6.5.0",
+		"@replit/codemirror-vim": "^6.2.1",
 		"@tauri-apps/api": "^1.5.3",
 		"@theopensource-company/feature-flags": "^0.4.5",
 		"@types/react-copy-to-clipboard": "^5.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@replit/codemirror-indentation-markers':
         specifier: ^6.5.0
         version: 6.5.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)
+      '@replit/codemirror-vim':
+        specifier: ^6.2.1
+        version: 6.2.1(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)
       '@tauri-apps/api':
         specifier: ^1.5.3
         version: 1.5.3
@@ -825,6 +828,15 @@ packages:
       '@codemirror/language': ^6.0.0
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
+
+  '@replit/codemirror-vim@6.2.1':
+    resolution: {integrity: sha512-qDAcGSHBYU5RrdO//qCmD8K9t6vbP327iCj/iqrkVnjbrpFhrjOt92weGXGHmTNRh16cUtkUZ7Xq7rZf+8HVow==}
+    peerDependencies:
+      '@codemirror/commands': ^6.0.0
+      '@codemirror/language': ^6.1.0
+      '@codemirror/search': ^6.2.0
+      '@codemirror/state': ^6.0.1
+      '@codemirror/view': ^6.0.3
 
   '@rollup/plugin-node-resolve@9.0.0':
     resolution: {integrity: sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==}
@@ -3620,6 +3632,14 @@ snapshots:
   '@replit/codemirror-indentation-markers@6.5.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)':
     dependencies:
       '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.24.1
+
+  '@replit/codemirror-vim@6.2.1(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)':
+    dependencies:
+      '@codemirror/commands': 6.3.3
+      '@codemirror/language': 6.10.1
+      '@codemirror/search': 6.5.6
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.24.1
 

--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "react";
 import { useSetting } from "~/hooks/config";
 import { Compartment, EditorState, Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { editorBase } from "~/util/editor/extensions";
+import { editorBase, userEditorKeymap } from "~/util/editor/extensions";
 import { forceLinting } from "@codemirror/lint";
 
 interface EditorRef {
@@ -18,6 +18,7 @@ export interface CodeEditorProps extends BoxProps {
 	extensions?: Extension[];
 	readOnly?: boolean;
 	autoFocus?: boolean;
+	userKeymap?: boolean;
 	onMount?: (editor: EditorView) => void;
 	onChange?: (value: string) => void;
 }
@@ -29,6 +30,7 @@ export function CodeEditor(props: CodeEditorProps) {
 		extensions,
 		className,
 		readOnly,
+		userKeymap,
 		autoFocus,
 		onMount,
 		...rest
@@ -37,6 +39,7 @@ export function CodeEditor(props: CodeEditorProps) {
 	const ref = useRef<HTMLDivElement | null>(null);
 	const editorRef = useRef<EditorRef>();
 	const [editorScale] = useSetting("appearance", "editorScale");
+	const [editorKeymap] = useSetting("behavior", "editorKeymap");
 
 	const textSize = Math.floor(15 * (editorScale / 100));
 
@@ -53,6 +56,9 @@ export function CodeEditor(props: CodeEditorProps) {
 		const initialState = EditorState.create({
 			doc: value,
 			extensions: [
+				userEditorKeymap(
+					!userKeymap || readOnly ? 'default': editorKeymap
+				),
 				editorBase(),
 				changeHandler,
 				editableExt,
@@ -83,7 +89,7 @@ export function CodeEditor(props: CodeEditorProps) {
 		return () => {
 			editor.destroy();
 		};
-	}, []);
+	}, [editorKeymap]);
 
 	useEffect(() => {
 		const { editor } = editorRef.current!;

--- a/src/components/CodeEditor/style.module.scss
+++ b/src/components/CodeEditor/style.module.scss
@@ -155,4 +155,15 @@
 		border-color: var(--mantine-color-slate-5);
 	}
 
+	:global(.cm-panels-bottom) {
+		// background-color: var(--mantine-color-slate-9);
+		border-top: 1px solid var(--surrealist-divider-color);
+	}
+
+	:global(.cm-vim-panel) {
+		padding-inline: var(--mantine-spacing-xs);
+		padding-top: var(--mantine-spacing-xs);
+		background-color: var(--mantine-color-body);
+		color: #737e98;
+	}
 }

--- a/src/components/Scaffold/settings/tabs/Behaviour.tsx
+++ b/src/components/Scaffold/settings/tabs/Behaviour.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, Kbd } from "@mantine/core";
+import { Checkbox, Kbd, Select } from "@mantine/core";
 import { adapter, isDesktop } from "~/adapter";
 import { useCheckbox } from "~/hooks/events";
 import { SettingsSection } from "../utilities";
 import { useSetting } from "~/hooks/config";
+import { EDITOR_KEYMAPS } from "~/constants";
 
 const CAT = "behavior";
 
@@ -13,6 +14,7 @@ export function BehaviourTab() {
 	const [queryErrorChecker, setQueryErrorChecker] = useSetting(CAT, "queryErrorChecker");
 	const [windowPinned, setWindowPinned] = useSetting(CAT, "windowPinned");
 	const [autoConnect, setAutoConnect] = useSetting(CAT, "autoConnect");
+	const [editorKeymap, setEditorKeymap] = useSetting(CAT, "editorKeymap");
 
 	const updateUpdateChecker = useCheckbox(setUpdateChecker);
 	const updateTableSuggest = useCheckbox(setTableSuggest);
@@ -64,6 +66,13 @@ export function BehaviourTab() {
 					label="Validate query for errors"
 					checked={queryErrorChecker}
 					onChange={updateQueryErrorChecker}
+				/>
+
+				<Select
+					label="Editor keymap"
+					data={EDITOR_KEYMAPS}
+					value={editorKeymap}
+					onChange={setEditorKeymap as any}
 				/>
 
 			</SettingsSection>

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -15,6 +15,7 @@ import {
 	ViewInfo,
 	ViewMode,
 	Orientation,
+	EditorKeymap,
 } from "./types";
 
 import {
@@ -214,4 +215,9 @@ export const SURQL_FILTERS = [
 export const ORIENTATIONS: Selectable<Orientation>[] = [
 	{ label: "Horizontal", value: "horizontal" },
 	{ label: "Vertical", value: "vertical" },
+];
+
+export const EDITOR_KEYMAPS: Selectable<EditorKeymap>[] = [
+	{ label: "Default", value: "default" },
+	{ label: "Vim", value: "vim" },
 ];

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -7,6 +7,7 @@ export type SourceMode = "schema" | "infer";
 export type DiagramMode = "fields" | "summary" | "simple";
 export type DiagramDirection = "ltr" | "rtl";
 export type ColorScheme = "light" | "dark";
+export type EditorKeymap = "vim" | "default";
 export type Platform = "darwin" | "windows" | "linux";
 export type TableType = "ANY" | "NORMAL" | "RELATION";
 export type ValueMode = "json" | "sql";
@@ -87,6 +88,7 @@ export interface SurrealistBehaviorSettings {
 	windowPinned: boolean;
 	autoConnect: boolean;
 	docsLanguage: CodeLang;
+	editorKeymap: EditorKeymap;
 }
 
 export interface SurrealistAppearanceSettings {

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -33,7 +33,8 @@ export function createBaseSettings(): SurrealistSettings {
 			queryErrorChecker: true,
 			windowPinned: false,
 			autoConnect: true,
-			docsLanguage: "cli"
+			docsLanguage: "cli",
+			editorKeymap: "default"
 		},
 		appearance: {
 			colorScheme: "dark",

--- a/src/util/editor/extensions.tsx
+++ b/src/util/editor/extensions.tsx
@@ -15,6 +15,8 @@ import { useDatabaseStore } from "~/stores/database";
 import { getActiveQuery } from "../connection";
 import { tryParseParams } from "../helpers";
 import { validateQuery } from "../surrealql";
+import { EditorKeymap } from "~/types";
+import { vim } from "@replit/codemirror-vim";
 
 /**
  * The color scheme used within editors
@@ -185,6 +187,19 @@ export const surqlVariableCompletion = (): Extension => {
 	return surrealqlLanguage.data.of({
 		autocomplete: VARIABLE_SOURCE
 	});
+};
+
+export const userEditorKeymap = (keymap: EditorKeymap): Extension => {
+	switch (keymap) {
+		case "vim": {
+			return vim({
+				status: true
+			});
+		}
+		case "default": {
+			return [];
+		}
+	}
 };
 
 /**

--- a/src/views/functions/EditorPanel/index.tsx
+++ b/src/views/functions/EditorPanel/index.tsx
@@ -85,6 +85,7 @@ export function EditorPanel({
 					onChange={value => onChange((draft: any) => {
 						draft.block = value;
 					})}
+					userKeymap
 					extensions={[
 						surrealql(),
 						surqlLinting(),

--- a/src/views/query/QueryPane/index.tsx
+++ b/src/views/query/QueryPane/index.tsx
@@ -188,6 +188,7 @@ export function QueryPane({
 			<CodeEditor
 				value={activeTab.query}
 				onChange={scheduleSetQuery}
+				userKeymap={true}
 				extensions={[
 					surrealql(),
 					surqlLinting(),

--- a/src/views/query/QueryPane/index.tsx
+++ b/src/views/query/QueryPane/index.tsx
@@ -188,7 +188,7 @@ export function QueryPane({
 			<CodeEditor
 				value={activeTab.query}
 				onChange={scheduleSetQuery}
-				userKeymap={true}
+				userKeymap
 				extensions={[
 					surrealql(),
 					surqlLinting(),


### PR DESCRIPTION
- Added [@replit/codemirror-vim](https://www.npmjs.com/package/@replit/codemirror-vim) dependency for vim keybindings
- Add select field for user key-map selection in Behavior tab of the Setting modal,
- Added vim mode in Query Pane and Function editor if user has enabled it the settings
- Added custom styling to vim status panel to match aesthetics

![image](https://github.com/surrealdb/surrealist/assets/11705150/29200c48-c049-4d1f-9025-2d11d4585024)
![image](https://github.com/surrealdb/surrealist/assets/11705150/a2330809-c271-4fb1-b919-91a805214bc2)


Q: Is a good idea to add this to any other multi-line editor in the app? - suggestion from #106 