### PR TITLE
Improve connection logic

### DIFF
--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -105,6 +105,24 @@ export function showError(info: {title: ReactNode, subtitle: ReactNode}) {
 }
 
 /**
+ * Display a warning notification
+ *
+ * @param title The title message
+ * @param subtitle The subtitle message
+ */
+export function showWarning(info: {title: ReactNode, subtitle: ReactNode}) {
+	showNotification({
+		color: "orange",
+		message: (
+			<Stack gap={0}>
+				<Text fw={600} c="bright">{info.title}</Text>
+				<Text>{info.subtitle}</Text>
+			</Stack>
+		),
+	});
+}
+
+/**
  * Display an informative notification
  *
  * @param title The title message

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -228,12 +228,27 @@ export function isPermissionError(result: any) {
  * @returns The URI string
  */
 export function connectionUri(options: ConnectionOptions) {
-	const basePath = options.protocol === "mem"
-		? `${options.protocol}://`
-		: `${options.protocol}://${options.hostname}`;
+	if (options.protocol === "mem") {
+		return "mem://";
+	} else if (options.protocol === "indxdb") {
+		return `indxdb://${options.hostname}`;
+	}
 
-	const url = new URL(basePath);
-	url.pathname = url.pathname === "/" ? "/rpc" : url.pathname;
+	const url = new URL(`${options.protocol}://${options.hostname}`);
+
+	// Optionally trim existing rpc
+	if (url.pathname.endsWith("rpc")) {
+		url.pathname = url.pathname.slice(0, -3);
+	}
+
+	// Append slash if missing
+	if (!url.pathname.endsWith("/")) {
+		url.pathname += "/";
+	}
+
+	// Append rpc
+	url.pathname += "rpc";
+
 	return url.toString();
 }
 
@@ -249,9 +264,22 @@ export function versionUri(options: ConnectionOptions) {
 	}
 
 	const protocol = options.protocol.replace(/^ws/, "http");
-	const versionURI = new URL("/version", `${protocol}://${options.hostname}`);
+	const url = new URL(`${protocol}://${options.hostname}`);
 
-	return versionURI.toString();
+	// Optionally trim existing rpc
+	if (url.pathname.endsWith("rpc")) {
+		url.pathname = url.pathname.slice(0, -3);
+	}
+
+	// Append slash if missing
+	if (!url.pathname.endsWith("/")) {
+		url.pathname += "/";
+	}
+
+	// Append version
+	url.pathname += "version";
+
+	return url.toString();
 }
 
 /**

--- a/src/util/version.tsx
+++ b/src/util/version.tsx
@@ -1,0 +1,70 @@
+import { ConnectionOptions } from "~/types";
+import { connectionUri, versionUri } from "./helpers";
+import { compare } from "semver";
+
+async function fetchRpcVersion(connection: ConnectionOptions) {
+	try {
+		const endpoint = connectionUri(connection);
+		const response = await fetch(endpoint, {
+			method: "POST",
+			body: JSON.stringify({ id: 1, method: "version" })
+		});
+
+		const json = await response.json();
+		const version = json.result as string;
+
+		if (typeof version !== "string") {
+			throw new TypeError("Invalid version response");
+		}
+
+		return version;
+	} catch {
+		return null;
+	}
+}
+
+async function fetchLegacyVersion(connection: ConnectionOptions) {
+	try {
+		const endpoint = versionUri(connection);
+
+		if (!endpoint) {
+			throw new Error("No version endpoint");
+		}
+
+		return await fetch(endpoint).then(res => res.text());
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Should we check the given connection for a database version
+ */
+export function shouldQueryDatabaseVersion(connection: ConnectionOptions) {
+	return connection.protocol !== "mem" && connection.protocol !== "indxdb";
+}
+
+/**
+ * Attempt to query the remote database version
+ */
+export async function queryDatabaseVersion(connection: ConnectionOptions) {
+	try {
+		const version = await fetchRpcVersion(connection) || await fetchLegacyVersion(connection);
+
+		if (!version) {
+			return null;
+		}
+
+		return version.replace(/^surrealdb-/, "").replace(/\+.+/, "");
+	} catch (err: any) {
+		console.error('Failed to retrieve database version', err);
+		return null;
+	}
+}
+
+/**
+ * Returns whether the given database version is unsupported
+ */
+export function isUnsupported(version: string) {
+	return compare(version, import.meta.env.SDB_VERSION) < 0;
+}


### PR DESCRIPTION
- Check version using /rpc and fallback to /version
- Show a warning when the version cannot be determined
- Allow for connecting to SurrealDB hosted on sub-paths
  - Awaiting new version of surrealdb.js