### PR TITLE
docs: update dotnet api docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"@theopensource-company/feature-flags": "^0.4.5",
 		"@types/react-copy-to-clipboard": "^5.0.7",
 		"ansi-to-html": "^0.7.2",
+		"camelcase": "^8.0.0",
 		"clsx": "^2.1.0",
 		"codemirror": "^6.0.1",
 		"codemirror-surrealql": "workspace:codemirror-surrealql",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       ansi-to-html:
         specifier: ^0.7.2
         version: 0.7.2
+      camelcase:
+        specifier: ^8.0.0
+        version: 8.0.0
       clsx:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1405,6 +1408,10 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   caniuse-lite@1.0.30001525:
     resolution: {integrity: sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==}
@@ -4211,6 +4218,8 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
+
+  camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001525: {}
 

--- a/src/docs/topics/concepts/full-text-search.tsx
+++ b/src/docs/topics/concepts/full-text-search.tsx
@@ -56,7 +56,7 @@ export function DocsConceptsFullTextSearch({ language, topic }: TopicProps) {
 		surrealdb.New("ws://cloud.surrealdb.com/rpc");
 		`,
 			csharp: `
-		await this.RawQuery(
+		await db.RawQuery(
 			"""
 				DEFINE TABLE page SCHEMALESS PERMISSIONS FOR select FULL;
 

--- a/src/docs/topics/schema/analyzers.tsx
+++ b/src/docs/topics/schema/analyzers.tsx
@@ -48,7 +48,7 @@ export function DocsSchemaAnalyzers({ language, topic }: TopicProps) {
 		surrealdb.New("ws://cloud.surrealdb.com/rpc");
 		`,
 			csharp: `
-		await this.RawQuery(
+		await db.RawQuery(
 			"""
 				DEFINE ANALYZER example_ngram TOKENIZERS class FILTERS ngram(1,3);
 			"""

--- a/src/docs/topics/schema/functions.tsx
+++ b/src/docs/topics/schema/functions.tsx
@@ -55,7 +55,7 @@ export function DocsSchemaFunctions({ language, topic }: TopicProps) {
 		surrealdb.New("ws://cloud.surrealdb.com/rpc");
 		`,
 			csharp: `
-			await this.RawQuery(
+			await db.RawQuery(
 				"""
 					-- It is necessary to prefix the name of your function with "fn::"
 					-- This indicates that it's a custom function

--- a/src/docs/topics/schema/scopes.tsx
+++ b/src/docs/topics/schema/scopes.tsx
@@ -55,7 +55,7 @@ export function DocsSchemaScopes({ language, topic }: TopicProps) {
 		surrealdb.New("ws://cloud.surrealdb.com/rpc");
 		`,
 			csharp: `
-		await this.RawQuery(
+		await db.RawQuery(
 			"""
 				-- Enable scope authentication directly in SurrealDB
 				DEFINE SCOPE account SESSION 24h

--- a/src/docs/topics/schema/users.tsx
+++ b/src/docs/topics/schema/users.tsx
@@ -50,7 +50,7 @@ export function DocsSchemaUsers({ language, topic }: TopicProps) {
 		surrealdb.New("ws://cloud.surrealdb.com/rpc");
 		`,
 			csharp: `
-		await this.RawQuery(
+		await db.RawQuery(
 			"""
 				-- Create a root user
 				DEFINE USER username ON ROOT PASSWORD '123456' ROLES OWNER;

--- a/src/docs/topics/tables/creating-records.tsx
+++ b/src/docs/topics/tables/creating-records.tsx
@@ -27,7 +27,7 @@ export function DocsTablesCreatingRecords({ language, topic }: TopicProps) {
 		db.Create("${table.schema.name}", map[string]interface{}{})
 		`,
 			csharp: `
-		db.Create<${table.schema.name}>("${table.schema.name}");
+		await db.Create("${table.schema.name}", data);
 		`,
 			java: `
 		driver.create(thing, data)

--- a/src/docs/topics/tables/deleting-records.tsx
+++ b/src/docs/topics/tables/deleting-records.tsx
@@ -27,7 +27,7 @@ export function DocsTablesDeletingRecords({ language, topic }: TopicProps) {
 		db.Delete("${table.schema.name}", map[string]interface{}{})
 		`,
 			csharp: `
-		db.delete<${table.schema.name}>("${table.schema.name}");
+		await db.Delete("${table.schema.name}");
 		`,
 			java: `
 		driver.delete(thing, data)

--- a/src/docs/topics/tables/inserting-records.tsx
+++ b/src/docs/topics/tables/inserting-records.tsx
@@ -38,7 +38,7 @@ export function DocsTablesInsertingRecords({ language, topic }: TopicProps) {
 		};")
 		`,
 			csharp: `
-		await db.Merge<${table.schema.name}>(merge);
+		await db.Merge("${table.schema.name}", data);
 		`,
 			java: `
 		`,

--- a/src/docs/topics/tables/live-selecting.tsx
+++ b/src/docs/topics/tables/live-selecting.tsx
@@ -4,6 +4,7 @@ import { Article, DocsPreview, TableTitle } from "~/docs/components";
 import { Snippets, TopicProps } from "~/docs/types";
 import { useActiveConnection } from "~/hooks/connection";
 import { getTable } from "~/docs/helpers";
+import { pascalCase } from "~/util/casing";
 
 export function DocsTablesLiveSelecting({ language, topic }: TopicProps) {
 	const { connection } = useActiveConnection();
@@ -56,7 +57,7 @@ table_name
 
 		`,
 			csharp: `
-		await using var liveQuery = db.ListenLive<${table.schema.name}>(queryUuid);
+		await using var liveQuery = db.ListenLive<${pascalCase(table.schema.name)}>(queryUuid);
 
 		// Option 1
 		// Consume the live query via an IAsyncEnumerable,
@@ -77,7 +78,7 @@ table_name
 			});
 
 
-		await using var liveQuery = await db.LiveQuery<${table.schema.name}>($"LIVE SELECT * FROM type::table({table});");
+		await using var liveQuery = await db.LiveQuery<${pascalCase(table.schema.name)}>($"LIVE SELECT * FROM type::table({table});");
 
 // Consume the live query...
 		`,

--- a/src/docs/topics/tables/select-all-fields.tsx
+++ b/src/docs/topics/tables/select-all-fields.tsx
@@ -4,6 +4,7 @@ import { Article, DocsPreview, TableTitle } from "~/docs/components";
 import { Snippets, TopicProps } from "~/docs/types";
 import { useActiveConnection } from "~/hooks/connection";
 import { getTable } from "~/docs/helpers";
+import { pascalCase } from "~/util/casing";
 
 export function DocsTablesSelectAllFields({ language, topic }: TopicProps) {
 	const table = getTable(topic);
@@ -27,7 +28,7 @@ export function DocsTablesSelectAllFields({ language, topic }: TopicProps) {
 		db.Select('${table.schema.name}');
 		`,
 			csharp: `
-		db.Select('${table.schema.name}');
+		await db.Select<${pascalCase(table.schema.name)}>("${table.schema.name}");
 		`,
 			java: `
 		driver.select("thing", rowType)

--- a/src/docs/topics/tables/select.tsx
+++ b/src/docs/topics/tables/select.tsx
@@ -31,9 +31,6 @@ export function DocsTablesSelect({ language, topic }: TopicProps) {
 			go: `
 
 		`,
-			csharp: `
-		db.Select('${fieldName}')
-		`,
 			java: `
 		driver.select("${fieldName}", rowType)
 		`,

--- a/src/docs/topics/tables/updating-records.tsx
+++ b/src/docs/topics/tables/updating-records.tsx
@@ -55,7 +55,7 @@ export function DocsTablesUpdatingRecords({ language, topic }: TopicProps) {
 		});
 		`,
 			csharp: `
-		await db.Upsert(${table.schema.name});
+		await db.Upsert("${table.schema.name}", data);
 		`,
 			java: `
 		// Connect to a local endpoint

--- a/src/util/casing.tsx
+++ b/src/util/casing.tsx
@@ -1,0 +1,3 @@
+import camelCase from 'camelcase';
+
+export const pascalCase = (input: string | readonly string[]) => camelCase(input, { pascalCase: true });


### PR DESCRIPTION
Update .NET API docs:
* Keep consistency across the examples
* Fix some examples (async/await, string)
* Use PascalCase for class names, following C# convention