### PR TITLE
feat: add additional keymap

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@mantine/notifications": "^7.6.2",
 		"@mdi/js": "^7.2.96",
 		"@replit/codemirror-indentation-markers": "^6.5.0",
+		"@replit/codemirror-vscode-keymap": "^6.0.2",
 		"@tauri-apps/api": "^1.5.3",
 		"@theopensource-company/feature-flags": "^0.4.5",
 		"@types/react-copy-to-clipboard": "^5.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@replit/codemirror-indentation-markers':
         specifier: ^6.5.0
         version: 6.5.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)
+      '@replit/codemirror-vscode-keymap':
+        specifier: ^6.0.2
+        version: 6.0.2(@codemirror/autocomplete@6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1))(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)
       '@tauri-apps/api':
         specifier: ^1.5.3
         version: 1.5.3
@@ -832,6 +835,17 @@ packages:
     resolution: {integrity: sha512-5RgeuQ6erfROi1EVI2X7G4UR+KByjb07jhYMynvpvlrV22JlnARifmKMGEUKy0pKcxBNfwbFqoUlTYHPgyZNlg==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+
+  '@replit/codemirror-vscode-keymap@6.0.2':
+    resolution: {integrity: sha512-j45qTwGxzpsv82lMD/NreGDORFKSctMDVkGRopaP+OrzSzv+pXDQuU3LnFvKpasyjVT0lf+PKG1v2DSCn/vxxg==}
+    peerDependencies:
+      '@codemirror/autocomplete': ^6.0.0
+      '@codemirror/commands': ^6.0.0
+      '@codemirror/language': ^6.0.0
+      '@codemirror/lint': ^6.0.0
+      '@codemirror/search': ^6.0.0
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
 
@@ -3646,6 +3660,16 @@ snapshots:
   '@replit/codemirror-indentation-markers@6.5.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)':
     dependencies:
       '@codemirror/language': 6.10.1
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.24.1
+
+  '@replit/codemirror-vscode-keymap@6.0.2(@codemirror/autocomplete@6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1))(@codemirror/commands@6.3.3)(@codemirror/language@6.10.1)(@codemirror/lint@6.5.0)(@codemirror/search@6.5.6)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)':
+    dependencies:
+      '@codemirror/autocomplete': 6.13.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.24.1)(@lezer/common@1.2.1)
+      '@codemirror/commands': 6.3.3
+      '@codemirror/language': 6.10.1
+      '@codemirror/lint': 6.5.0
+      '@codemirror/search': 6.5.6
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.24.1
 

--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -7,6 +7,7 @@ import { Compartment, EditorState, Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { editorBase } from "~/util/editor/extensions";
 import { forceLinting } from "@codemirror/lint";
+import { useInterfaceStore } from "~/stores/interface";
 
 interface EditorRef {
 	editor: EditorView;
@@ -37,6 +38,8 @@ export function CodeEditor(props: CodeEditorProps) {
 	const ref = useRef<HTMLDivElement | null>(null);
 	const editorRef = useRef<EditorRef>();
 	const [editorScale] = useSetting("appearance", "editorScale");
+
+	const setHasEditorFocus = useInterfaceStore((s) => s.setHasEditorFocus);
 
 	const textSize = Math.floor(15 * (editorScale / 100));
 
@@ -71,6 +74,16 @@ export function CodeEditor(props: CodeEditorProps) {
 			editable
 		};
 
+		const handleFocus =  () => {
+			setHasEditorFocus(true);
+		};
+		const handleBlur = () => {
+			setHasEditorFocus(false);
+		};
+
+		editor.contentDOM.addEventListener("focus", handleFocus);
+		editor.contentDOM.addEventListener("blur", handleBlur);
+
 		if (autoFocus) {
 			const timer = setInterval(() => {
 				editor.focus();
@@ -81,7 +94,10 @@ export function CodeEditor(props: CodeEditorProps) {
 		onMount?.(editor);
 
 		return () => {
+			editor.contentDOM.removeEventListener("focus", handleFocus);
+			editor.contentDOM.removeEventListener("blur", handleBlur);
 			editor.destroy();
+			setHasEditorFocus(false);
 		};
 	}, []);
 

--- a/src/components/Scaffold/index.tsx
+++ b/src/components/Scaffold/index.tsx
@@ -33,7 +33,6 @@ import { Sidebar } from "../Sidebar";
 import { CommandPaletteModal } from "./modals/palette";
 import { useBoolean } from "~/hooks/boolean";
 import { useWindowSettings } from "./hooks";
-import { useCompatHotkeys } from "~/hooks/hotkey";
 import { FunctionsView } from "~/views/functions/FunctionsView";
 import { ModelsView } from "~/views/models/ModelsView";
 import { LegacyModal } from "./modals/legacy";
@@ -44,6 +43,8 @@ import { Icon } from "../Icon";
 import { iconOpen } from "~/util/icons";
 import { isMobile } from "~/util/helpers";
 import { EmbedderModal } from "./modals/embedder";
+import { useCompatHotkeys } from "~/hooks/hotkey";
+import { useCallback } from "react";
 
 const PORTAL_ATTRS = {
 	attributes: {
@@ -65,6 +66,7 @@ export function Scaffold() {
 	const isLight = useIsLight();
 
 	const title = useInterfaceStore((s) => s.title);
+	const hasEditorFocus = useInterfaceStore((s) => s.hasEditorFocus);
 	const activeConnection = useConfigStore((s) => s.activeConnection);
 	const activeView = useConfigStore((s) => s.activeView);
 
@@ -74,9 +76,11 @@ export function Scaffold() {
 
 	const viewNode = VIEW_PORTALS[activeView];
 
+	const noop = useCallback(() => {}, []);
+
 	useWindowSettings();
 	useCompatHotkeys([
-		["mod+K", paletteHandle.open]
+		["mod+K", hasEditorFocus ? noop : paletteHandle.open]
 	]);
 
 	return (

--- a/src/hooks/hotkey.ts
+++ b/src/hooks/hotkey.ts
@@ -17,5 +17,5 @@ export function useCompatHotkeys(hotkeys: HotkeyItem[]) {
 		return () => {
 			document.body.removeEventListener('keydown', handler);
 		};
-	}, []);
+	}, [hotkeys]);
 }

--- a/src/stores/interface.tsx
+++ b/src/stores/interface.tsx
@@ -24,6 +24,7 @@ export type InterfaceStore = {
 	showScopeSignup: boolean;
 	showChangelogAlert: boolean;
 	hasReadChangelog: boolean;
+	hasEditorFocus: boolean;
 
 	setWindowTitle: (title: string) => void;
 	setColorPreference: (preference: ColorScheme) => void;
@@ -42,6 +43,7 @@ export type InterfaceStore = {
 	closeScopeSignup: () => void;
 	showChangelog: () => void;
 	readChangelog: () => void;
+	setHasEditorFocus: (hasFocus: boolean) => void;
 };
 
 export const useInterfaceStore = create<InterfaceStore>((set) => ({
@@ -59,6 +61,7 @@ export const useInterfaceStore = create<InterfaceStore>((set) => ({
 	showScopeSignup: false,
 	showChangelogAlert: false,
 	hasReadChangelog: false,
+	hasEditorFocus: false,
 
 	setWindowTitle: (title) => set(() => ({ title })),
 
@@ -153,4 +156,7 @@ export const useInterfaceStore = create<InterfaceStore>((set) => ({
 		hasReadChangelog: true,
 	})),
 
+	setHasEditorFocus: (hasFocus) => set(() => ({
+		hasEditorFocus: hasFocus,
+	})),
 }));

--- a/src/util/editor/extensions.tsx
+++ b/src/util/editor/extensions.tsx
@@ -15,6 +15,7 @@ import { useDatabaseStore } from "~/stores/database";
 import { getActiveQuery } from "../connection";
 import { tryParseParams } from "../helpers";
 import { validateQuery } from "../surrealql";
+import { vscodeKeymap } from "@replit/codemirror-vscode-keymap";
 
 /**
  * The color scheme used within editors
@@ -55,6 +56,7 @@ export const editorBase = (): Extension => [
 		highlightWordAroundCursor: true,
 		wholeWords: true
 	}),
+	keymap.of(vscodeKeymap),
 	keymap.of([
 		runQuery,
 		acceptWithTab,


### PR DESCRIPTION
Improve experience by adding vscode keymap.
At least for me, it make `CTRL+K+C` and `CTRL+K+U` works.

* Add `vscode-keymap` plugin to add additional keymaps https://github.com/replit/codemirror-vscode-keymap
* Disable `mod+K` hotkey confitionally (disabled when in-editor) to be able to use `CTRL+K+C` and `CTRL+K+U`. Search window still works outside the query editor
* Added `hasEditorFocus` and `setHasEditorFocus` in the `InterfaceStore`

Note: there is a warning to set `defaultKeymap: false`. I did not make this change and still to work as-is. I am note sure if anything is broken.