### PR TITLE
fix: fix loading of records in explorer view

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
 		"eslint:recommended",
 		"plugin:@typescript-eslint/eslint-recommended",
 		"plugin:@typescript-eslint/recommended",
-		"plugin:unicorn/recommended"
+		"plugin:unicorn/recommended",
+		"plugin:@tanstack/eslint-plugin-query/recommended"
 	],
 	"rules": {
 		"semi": 2,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"@mantine/notifications": "^7.6.2",
 		"@mdi/js": "^7.2.96",
 		"@replit/codemirror-indentation-markers": "^6.5.0",
+		"@tanstack/react-query": "^5.37.1",
 		"@tauri-apps/api": "2.0.0-beta.11",
 		"@tauri-apps/plugin-dialog": "2.0.0-beta.3",
 		"@tauri-apps/plugin-fs": "2.0.0-beta.3",
@@ -88,6 +89,7 @@
 		"zustand": "^4.5.0"
 	},
 	"devDependencies": {
+		"@tanstack/eslint-plugin-query": "^5.35.6",
 		"@tauri-apps/cli": "2.0.0-beta.16",
 		"@types/node": "^20.4.9",
 		"@types/react": "^18.2.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@replit/codemirror-indentation-markers':
         specifier: ^6.5.0
         version: 6.5.1(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)
+      '@tanstack/react-query':
+        specifier: ^5.37.1
+        version: 5.37.1(react@18.3.1)
       '@tauri-apps/api':
         specifier: 2.0.0-beta.11
         version: 2.0.0-beta.11
@@ -204,6 +207,9 @@ importers:
         specifier: ^4.5.0
         version: 4.5.2(@types/react@18.3.2)(immer@10.1.1)(react@18.3.1)
     devDependencies:
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.35.6
+        version: 5.35.6(eslint@8.57.0)(typescript@5.4.5)
       '@tauri-apps/cli':
         specifier: 2.0.0-beta.16
         version: 2.0.0-beta.16
@@ -930,6 +936,19 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@tanstack/eslint-plugin-query@5.35.6':
+    resolution: {integrity: sha512-XhVRLsJFJMWYNzArPzy1MWSpx2BSUnc8Zof+fvsgaAnWBy9tjNXH3DFftZoNMGA8Mw1dPIdDPkEQcSku3m80Jw==}
+    peerDependencies:
+      eslint: ^8.0.0
+
+  '@tanstack/query-core@5.36.1':
+    resolution: {integrity: sha512-BteWYEPUcucEu3NBcDAgKuI4U25R9aPrHSP6YSf2NvaD2pSlIQTdqOfLRsxH9WdRYg7k0Uom35Uacb6nvbIMJg==}
+
+  '@tanstack/react-query@5.37.1':
+    resolution: {integrity: sha512-EhtBNA8GL3XFeSx6VYUjXQ96n44xe3JGKZCzBINrCYlxbZP6UwBafv7ti4eSRWc2Fy+fybQre0w17gR6lMzULA==}
+    peerDependencies:
+      react: ^18.0.0
 
   '@tauri-apps/api@2.0.0-beta.11':
     resolution: {integrity: sha512-wJRY+fBUm3KpqZDHMIz5HRv+1vlnvRJ/dFxiyY3NlINTx2qXqDou5qWYcP1CuZXsd39InWVPV3FAZvno/kGCkA==}
@@ -3891,6 +3910,21 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tanstack/eslint-plugin-query@5.35.6(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@tanstack/query-core@5.36.1': {}
+
+  '@tanstack/react-query@5.37.1(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.36.1
+      react: 18.3.1
 
   '@tauri-apps/api@2.0.0-beta.11': {}
 

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -19,6 +19,12 @@ import { useUrlHandler } from "~/hooks/url";
 import { AppErrorHandler } from "./error";
 import { useConfigStore } from "~/stores/config";
 import { SANDBOX } from "~/constants";
+import {
+	QueryClient,
+	QueryClientProvider,
+} from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 export function App() {
 	const { hideAvailableUpdate } = useInterfaceStore.getState();
@@ -47,69 +53,71 @@ export function App() {
 
 	return (
 		<FeatureFlagsProvider>
-			<MantineProvider
-				withCssVariables
-				theme={MANTINE_THEME}
-				forceColorScheme={colorScheme}
-			>
-				<Notifications />
-
-				<ContextMenuProvider
-					borderRadius="md"
-					shadow={isLight ? "xs" : "0 6px 12px 2px rgba(0, 0, 0, 0.25)"}
-					submenuDelay={250}
+			<QueryClientProvider client={queryClient}>
+				<MantineProvider
+					withCssVariables
+					theme={MANTINE_THEME}
+					forceColorScheme={colorScheme}
 				>
-					<ConfirmationProvider>
-						<InspectorProvider>
-							<ErrorBoundary
-								FallbackComponent={AppErrorHandler}
-								onReset={handleReset}
-							>
-								<Scaffold />
-							</ErrorBoundary>
-						</InspectorProvider>
-					</ConfirmationProvider>
-				</ContextMenuProvider>
+					<Notifications />
 
-				<Transition
-					mounted={showUpdate}
-					duration={250}
-					transition="slide-up"
-					timingFunction="ease"
-				>
-					{(styles) => (
-						<Paper
-							onClick={openRelease}
-							style={{ ...styles, cursor: "pointer" }}
-							pos="fixed"
-							bg="#2f2f40"
-							bottom={20}
-							left={20}
-							p="xs"
-						>
-							<Group gap="sm">
-								<Image
-									src={surrealistIcon}
-									style={{ pointerEvents: "none" }}
-									height={32}
-									width={32}
-									mx={4}
-								/>
-								<Box miw={200}>
-									<Text c="white">New release available</Text>
-									<Text c="gray.5">Version {update} is available</Text>
-								</Box>
-								<ActionIcon
-									aria-label="Close update notification"
-									onClick={closeUpdate}
+					<ContextMenuProvider
+						borderRadius="md"
+						shadow={isLight ? "xs" : "0 6px 12px 2px rgba(0, 0, 0, 0.25)"}
+						submenuDelay={250}
+					>
+						<ConfirmationProvider>
+							<InspectorProvider>
+								<ErrorBoundary
+									FallbackComponent={AppErrorHandler}
+									onReset={handleReset}
 								>
-									<Icon path={iconClose} />
-								</ActionIcon>
-							</Group>
-						</Paper>
-					)}
-				</Transition>
-			</MantineProvider>
+									<Scaffold />
+								</ErrorBoundary>
+							</InspectorProvider>
+						</ConfirmationProvider>
+					</ContextMenuProvider>
+
+					<Transition
+						mounted={showUpdate}
+						duration={250}
+						transition="slide-up"
+						timingFunction="ease"
+					>
+						{(styles) => (
+							<Paper
+								onClick={openRelease}
+								style={{ ...styles, cursor: "pointer" }}
+								pos="fixed"
+								bg="#2f2f40"
+								bottom={20}
+								left={20}
+								p="xs"
+							>
+								<Group gap="sm">
+									<Image
+										src={surrealistIcon}
+										style={{ pointerEvents: "none" }}
+										height={32}
+										width={32}
+										mx={4}
+									/>
+									<Box miw={200}>
+										<Text c="white">New release available</Text>
+										<Text c="gray.5">Version {update} is available</Text>
+									</Box>
+									<ActionIcon
+										aria-label="Close update notification"
+										onClick={closeUpdate}
+									>
+										<Icon path={iconClose} />
+									</ActionIcon>
+								</Group>
+							</Paper>
+						)}
+					</Transition>
+				</MantineProvider>
+			</QueryClientProvider>
 		</FeatureFlagsProvider>
 	);
 }

--- a/src/components/Pane/index.tsx
+++ b/src/components/Pane/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Group, Paper, PaperProps, Text } from "@mantine/core";
+import { Box, Divider, Group, LoadingOverlay, Paper, PaperProps, Text } from "@mantine/core";
 import { HTMLAttributes } from "react";
 import { useIsLight } from "~/hooks/theme";
 import { Icon } from "../Icon";
@@ -9,6 +9,7 @@ export interface ContentPaneProps extends PaperProps, Omit<HTMLAttributes<HTMLDi
 	title?: string;
 	icon?: string;
 	leftSection?: React.ReactNode;
+	loading?: boolean;
 	rightSection?: React.ReactNode;
 	withTopPadding?: boolean;
 }
@@ -18,6 +19,7 @@ export function ContentPane({
 	title,
 	icon,
 	leftSection,
+	loading,
 	rightSection,
 	withTopPadding,
 	...rest
@@ -29,8 +31,16 @@ export function ContentPane({
 		<Paper
 			radius="lg"
 			className={classes.root}
+			pos="relative"
 			{...rest}
 		>
+			<LoadingOverlay
+				visible={loading}
+				zIndex={1000}
+				overlayProps={{ radius: 'sm', blur: 0 }}
+				loaderProps={{ type: 'dots' }}
+			>
+			</LoadingOverlay>
 			{title !== undefined && icon !== undefined && (
 				<>
 					<Group


### PR DESCRIPTION
Fix loading of records, especially when switching tables that takes some time to load.

* Add `@tanstack/react-query` and `@tanstack/eslint-plugin-query` packages
* `useQuery` to simplify the loading logic of records (having `isLoading`, `data` and `refresh` properties already available)
* use `LoadingOverlay` from mantime when records are loading

Example:

![image](https://github.com/surrealdb/surrealist/assets/6053067/e693caac-ce95-426a-8c09-53478689453c)


