### PR TITLE
feature: Pretty print using serde_json correctly

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1477,15 +1477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,16 +1980,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "treediff",
-]
-
-[[package]]
-name = "jsonxf"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6889ea54a6add10ed8a757719ec88293201265fa7fe56e09ae66b6df038a6"
-dependencies = [
- "getopts",
- "memchr",
 ]
 
 [[package]]
@@ -3700,7 +3681,6 @@ name = "surrealist"
 version = "0.0.0"
 dependencies = [
  "dirs-next",
- "jsonxf",
  "log",
  "openssl",
  "portpicker",
@@ -4650,12 +4630,6 @@ name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,6 @@ tauri-plugin-single-instance = "2.0.0-beta.7"
 portpicker = "0.1"
 serde_json = "1.0"
 dirs-next = "2.0.0"
-jsonxf = "1.1.1"
 serde = { version = "1.0", features = ["derive"] }
 log = "^0.4"
 url = "2"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -15,7 +15,9 @@ fn write_config(config: &str) {
 
     let mut write_op = File::create(config_path).unwrap();
     let config_json_value: serde_json::Value = serde_json::from_str(config).unwrap();
-    let pretty_config = serde_json::to_string_pretty(&config_json_value).unwrap();
+    let mut pretty_config = serde_json::to_string_pretty(&config_json_value).unwrap();
+
+	pretty_config.push_str("\n");
 
     write_op
         .write_all(pretty_config.as_bytes())

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -17,7 +17,7 @@ fn write_config(config: &str) {
     let config_json_value: serde_json::Value = serde_json::from_str(config).unwrap();
     let mut pretty_config = serde_json::to_string_pretty(&config_json_value).unwrap();
 
-	pretty_config.push_str("\n");
+    pretty_config.push_str("\n");
 
     write_op
         .write_all(pretty_config.as_bytes())

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -17,7 +17,7 @@ fn write_config(config: &str) {
     let config_json_value: serde_json::Value = serde_json::from_str(config).unwrap();
     let mut pretty_config = serde_json::to_string_pretty(&config_json_value).unwrap();
 
-    pretty_config.push_str("\n");
+    pretty_config.push('\n');
 
     write_op
         .write_all(pretty_config.as_bytes())

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -14,8 +14,9 @@ fn write_config(config: &str) {
     fs::create_dir_all(parent).expect("config directory should be writable");
 
     let mut write_op = File::create(config_path).unwrap();
-    let pretty_config = jsonxf::pretty_print(config).unwrap();
-
+    let config_json_value: serde_json::Value = serde_json::from_str(config).unwrap();
+    let pretty_config = serde_json::to_string_pretty(&config_json_value).unwrap();
+	
     write_op
         .write_all(pretty_config.as_bytes())
         .expect("config should be writable");

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -16,7 +16,7 @@ fn write_config(config: &str) {
     let mut write_op = File::create(config_path).unwrap();
     let config_json_value: serde_json::Value = serde_json::from_str(config).unwrap();
     let pretty_config = serde_json::to_string_pretty(&config_json_value).unwrap();
-	
+
     write_op
         .write_all(pretty_config.as_bytes())
         .expect("config should be writable");


### PR DESCRIPTION
It is necessary to use serde_json::from_str to convert the config str into a serde_json::Value then use serde_json::to_string_pretty to get a proper pretty printed result.

This costs an additional line of code and an unknown performance difference, but it does reduce
the number of dependencies by 3 removing getopts, jsonxf and unicode-width. I also results in
a very slight reduction in the release binary. For jsonxf the size was 27,679,424 compared to serde_json at
27,661,224. Which is 18,200 bytes but as a percentage it's tiny at (18200/27661224)*100 = 0.0658%.

Here is the data.
```
$ find . -type f -name 'surrealist' -print0 | xargs -0 stat --format="%s %n"
265382360 ./src-tauri/target-main-using-jsonxf/debug/surrealist
27679424 ./src-tauri/target-main-using-jsonxf/release/bundle/appimage_deb/data/usr/bin/surrealist
27679424 ./src-tauri/target-main-using-jsonxf/release/bundle/appimage/surrealist.AppDir/usr/bin/surrealist
27679424 ./src-tauri/target-main-using-jsonxf/release/bundle/deb/surrealist_2.0.6_amd64/data/usr/bin/surrealist
27679424 ./src-tauri/target-main-using-jsonxf/release/surrealist
265040760 ./src-tauri/target-pretty-print-using-serde_json-correctly/debug/surrealist
27661224 ./src-tauri/target-pretty-print-using-serde_json-correctly/release/bundle/appimage_deb/data/usr/bin/surrealist
27661224 ./src-tauri/target-pretty-print-using-serde_json-correctly/release/bundle/appimage/surrealist.AppDir/usr/bin/surrealist
27661224 ./src-tauri/target-pretty-print-using-serde_json-correctly/release/bundle/deb/surrealist_2.0.6_amd64/data/usr/bin/surrealist
27661224 ./src-tauri/target-pretty-print-using-serde_json-correctly/release/surrealist
```

I also visually verified the two config.json outputs, the jsonxf seems to preserve the order of the original string
where as the conversion from a string to a json value then back to a string, as done by serde_json, definitely does not.
Finally, I did a quick verification that the jsonxf and serde_json versions could process each other config.json files.
The one thing I didn't do was measure performance differences.

Two other data points:
 * serde_json is already used by the project, has been downloaded 260,000,000+ and
    the most recent release was 16 days ago, https://crates.io/search?q=serde_json.
 * jsonxf has been downloaded about 100,000 with the most recent release 3 years ago,
   https://crates.io/search?q=jsonxf.

Therefore I'd choose serde_json.
