### PR TITLE
chore: use code-splitting techniques

### DIFF
--- a/src/components/NavigationIcon/index.tsx
+++ b/src/components/NavigationIcon/index.tsx
@@ -25,6 +25,7 @@ export function NavigationIcon({
 	const hasIcon = typeof icon === 'string';
 
 	const {
+		isLoading,
 		ref,
 		onMouseEnter,
 		onMouseLeave
@@ -48,6 +49,7 @@ export function NavigationIcon({
 				<Entry
 					className={clsx(classes.viewButton, isActive && classes.viewButtonActive)}
 					isActive={isActive}
+					style={{ opacity: isLoading ? 0 : 1 }}
 					onClick={onClick}
 					leftSection={
 						hasIcon ? (

--- a/src/components/Scaffold/index.tsx
+++ b/src/components/Scaffold/index.tsx
@@ -13,11 +13,7 @@ import { Toolbar } from "../Toolbar";
 import { useDisclosure } from "@mantine/hooks";
 import { ConnectionEditor } from "./modals/connection";
 import { InPortal, OutPortal, createHtmlPortalNode, HtmlPortalNode } from "react-reverse-portal";
-import { QueryView } from "~/views/query/QueryView";
 import { ViewMode } from "~/types";
-import { ExplorerView } from "~/views/explorer/ExplorerView";
-import { DesignerView } from "~/views/designer/DesignerView";
-import { AuthenticationView } from "~/views/authentication/AuthenticationView";
 import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
 import { Settings } from "./settings";
@@ -28,14 +24,11 @@ import { StartScreen } from "./start";
 import { TableCreator } from "./modals/table";
 import { DownloadModal } from "./modals/download";
 import { ScopeSignup } from "./modals/signup";
-import { DocumentationView } from "~/views/documentation/DocumentationView";
 import { Sidebar } from "../Sidebar";
 import { CommandPaletteModal } from "./modals/palette";
 import { useBoolean } from "~/hooks/boolean";
 import { useWindowSettings } from "./hooks";
 import { useCompatHotkeys } from "~/hooks/hotkey";
-import { FunctionsView } from "~/views/functions/FunctionsView";
-import { ModelsView } from "~/views/models/ModelsView";
 import { LegacyModal } from "./modals/legacy";
 import { SandboxModal } from "./modals/sandbox";
 import { ChangelogModal } from "./modals/changelog";
@@ -45,6 +38,7 @@ import { iconOpen } from "~/util/icons";
 import { isMobile } from "~/util/helpers";
 import { EmbedderModal } from "./modals/embedder";
 import { useSetting } from "~/hooks/config";
+import { Suspense, lazy } from "react";
 
 const PORTAL_ATTRS = {
 	attributes: {
@@ -61,6 +55,14 @@ const VIEW_PORTALS: Record<ViewMode, HtmlPortalNode> = {
 	models: createHtmlPortalNode(PORTAL_ATTRS),
 	documentation: createHtmlPortalNode(PORTAL_ATTRS),
 };
+
+const QueryView = lazy(() => import('~/views/query/QueryView'));
+const ExplorerView = lazy(() => import('~/views/explorer/ExplorerView'));
+const DesignerView = lazy(() => import('~/views/designer/DesignerView'));
+const AuthenticationView = lazy(() => import('~/views/authentication/AuthenticationView'));
+const FunctionsView = lazy(() => import('~/views/functions/FunctionsView'));
+const ModelsView = lazy(() => import('~/views/models/ModelsView'));
+const DocumentationView = lazy(() => import('~/views/documentation/DocumentationView'));
 
 export function Scaffold() {
 	const isLight = useIsLight();
@@ -157,31 +159,45 @@ export function Scaffold() {
 						</Box>
 
 						<InPortal node={VIEW_PORTALS.query}>
-							<QueryView />
+							<Suspense fallback={null}>
+								<QueryView />
+							</Suspense>
 						</InPortal>
 
 						<InPortal node={VIEW_PORTALS.explorer}>
-							<ExplorerView />
+							<Suspense fallback={null}>
+								<ExplorerView />
+							</Suspense>
 						</InPortal>
 
 						<InPortal node={VIEW_PORTALS.designer}>
-							<DesignerView />
+							<Suspense fallback={null}>
+								<DesignerView />
+							</Suspense>
 						</InPortal>
 
 						<InPortal node={VIEW_PORTALS.authentication}>
-							<AuthenticationView />
+							<Suspense fallback={null}>
+								<AuthenticationView />
+							</Suspense>
 						</InPortal>
 
 						<InPortal node={VIEW_PORTALS.functions}>
-							<FunctionsView />
+							<Suspense fallback={null}>
+								<FunctionsView />
+							</Suspense>
 						</InPortal>
 
 						<InPortal node={VIEW_PORTALS.models}>
-							<ModelsView />
+							<Suspense fallback={null}>
+								<ModelsView />
+							</Suspense>
 						</InPortal>
 
 						<InPortal node={VIEW_PORTALS.documentation}>
-							<DocumentationView />
+							<Suspense fallback={null}>
+								<DocumentationView />
+							</Suspense>
 						</InPortal>
 					</>
 				) : (

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,8 +1,3 @@
-import queryIcon from "~/assets/animation/query.json";
-import explorerIcon from "~/assets/animation/explorer.json";
-import designerIcon from "~/assets/animation/designer.json";
-import authIcon from "~/assets/animation/auth.json";
-
 import {
 	AuthMode,
 	CodeLang,
@@ -110,28 +105,28 @@ export const VIEW_MODES: Record<ViewMode, ViewInfo> = {
 		id: "query",
 		name: "Query",
 		icon: iconQuery,
-		anim: queryIcon,
+		anim: import("~/assets/animation/query.json").then(x => x.default),
 		desc: "Execute queries against the database and inspect the results",
 	},
 	explorer: {
 		id: "explorer",
 		name: "Explorer",
 		icon: iconExplorer,
-		anim: explorerIcon,
+		anim: import("~/assets/animation/explorer.json").then(x => x.default),
 		desc: "Explore the database tables, records, and relations",
 	},
 	designer: {
 		id: "designer",
 		name: "Designer",
 		icon: iconDesigner,
-		anim: designerIcon,
+		anim: import("~/assets/animation/designer.json").then(x => x.default),
 		desc: "Define database tables and relations",
 	},
 	authentication: {
 		id: "authentication",
 		name: "Authentication",
 		icon: iconAuth,
-		anim: authIcon,
+		anim: import("~/assets/animation/auth.json").then(x => x.default),
 		desc: "Manage account details and database scopes",
 	},
 	functions: {

--- a/src/hooks/hover-icon.ts
+++ b/src/hooks/hover-icon.ts
@@ -48,6 +48,7 @@ export function useHoverIcon(options: HoverIconOptions) {
 		queryKey: ["lottie", id],
 		queryFn: async () => {
 			const lottie = await import('lottie-web/build/player/lottie_light');
+			const animationData = await Promise.resolve(options.animation);
 
 			if (isMounted && ref.current && !ref.current.innerHTML) {
 				const item = lottie.default.loadAnimation({
@@ -55,7 +56,7 @@ export function useHoverIcon(options: HoverIconOptions) {
 					renderer: 'svg',
 					autoplay: false,
 					loop: false,
-					animationData: options.animation,
+					animationData,
 					rendererSettings: {
 						className: options.className
 					},

--- a/src/hooks/hover-icon.ts
+++ b/src/hooks/hover-icon.ts
@@ -45,6 +45,7 @@ export function useHoverIcon(options: HoverIconOptions) {
 	const id = useId();
 
 	const { isPending } = useQuery({
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
 		queryKey: ["lottie", id],
 		queryFn: async () => {
 			const lottie = await import('lottie-web/build/player/lottie_light');
@@ -63,7 +64,11 @@ export function useHoverIcon(options: HoverIconOptions) {
 				});
 
 				itemRef.current = item;
+
+				return true;
 			}
+
+			return false;
 		},
 		enabled: isMounted,
 	});

--- a/src/views/authentication/AuthenticationView/index.tsx
+++ b/src/views/authentication/AuthenticationView/index.tsx
@@ -55,3 +55,5 @@ export function AuthenticationView() {
 		</SimpleGrid>
 	);
 }
+
+export default AuthenticationView;

--- a/src/views/designer/DesignerView/index.tsx
+++ b/src/views/designer/DesignerView/index.tsx
@@ -134,3 +134,5 @@ export function DesignerView(_props: DesignerViewProps) {
 		// </Splitter>
 	);
 }
+
+export default DesignerView;

--- a/src/views/designer/TableGraphPane/helpers.tsx
+++ b/src/views/designer/TableGraphPane/helpers.tsx
@@ -4,7 +4,6 @@ import { DiagramDirection, TableInfo } from "~/types";
 import { extractEdgeRecords } from "~/util/schema";
 import { Edge, Node, NodeChange, Position } from "reactflow";
 import { toBlob, toSvg } from "html-to-image";
-import ELK from "elkjs/lib/elk.bundled";
 
 export const NODE_TYPES = {
 	table: TableNode,
@@ -129,7 +128,8 @@ export async function applyNodeLayout(
 		return [];
 	}
 
-	const elk = new ELK();
+	const ELK = await import("elkjs/lib/elk.bundled");
+	const elk = new ELK.default();
 	const graph = {
 		id: 'root',
 		children: nodes.map(node => ({

--- a/src/views/documentation/DocumentationView/index.tsx
+++ b/src/views/documentation/DocumentationView/index.tsx
@@ -45,3 +45,5 @@ export function DocumentationView() {
 		</>
 	);
 }
+
+export default DocumentationView;

--- a/src/views/explorer/ExplorerView/index.tsx
+++ b/src/views/explorer/ExplorerView/index.tsx
@@ -121,3 +121,5 @@ export function ExplorerView() {
 		</>
 	);
 }
+
+export default ExplorerView;

--- a/src/views/explorer/ExplorerView/index.tsx
+++ b/src/views/explorer/ExplorerView/index.tsx
@@ -52,7 +52,10 @@ export function ExplorerView() {
 	return (
 		<>
 			<Box h="100%" ref={ref}>
-				<PanelGroup direction="horizontal">
+				<PanelGroup
+					direction="horizontal"
+					style={{ opacity: minSize === 0 ? 0 : 1 }}
+				>
 					<Panel
 						defaultSize={minSize}
 						minSize={minSize}

--- a/src/views/functions/FunctionsView/index.tsx
+++ b/src/views/functions/FunctionsView/index.tsx
@@ -247,3 +247,5 @@ export function FunctionsView() {
 		</>
 	);
 }
+
+export default FunctionsView;

--- a/src/views/functions/FunctionsView/index.tsx
+++ b/src/views/functions/FunctionsView/index.tsx
@@ -120,7 +120,10 @@ export function FunctionsView() {
 	return (
 		<>
 			<Box h="100%" ref={ref}>
-				<PanelGroup direction="horizontal">
+				<PanelGroup
+					direction="horizontal"
+					style={{ opacity: minSize === 0 ? 0 : 1 }}
+				>
 					<Panel
 						defaultSize={minSize}
 						minSize={minSize}

--- a/src/views/models/ModelsView/index.tsx
+++ b/src/views/models/ModelsView/index.tsx
@@ -189,3 +189,5 @@ export function ModelsView() {
 		</Group>
 	);
 }
+
+export default ModelsView;

--- a/src/views/query/QueryPane/index.tsx
+++ b/src/views/query/QueryPane/index.tsx
@@ -1,4 +1,3 @@
-import autoFixAnim from "~/assets/animation/autofix.json";
 import { useStable } from "~/hooks/stable";
 import { ContentPane } from "~/components/Pane";
 import { useDebouncedFunction } from "~/hooks/debounce";
@@ -148,7 +147,7 @@ export function QueryPane({
 							<HoverIcon
 								color="slate"
 								onClick={inferVariables}
-								animation={autoFixAnim}
+								animation={import("~/assets/animation/autofix.json").then(x => x.default)}
 							/>
 						</Tooltip>
 

--- a/src/views/query/QueryView/index.tsx
+++ b/src/views/query/QueryView/index.tsx
@@ -344,3 +344,5 @@ export function QueryView() {
 		</Stack>
 	);
 }
+
+export default QueryView;

--- a/src/views/query/QueryView/index.tsx
+++ b/src/views/query/QueryView/index.tsx
@@ -234,7 +234,11 @@ export function QueryView() {
 					</Box>
 				</>
 			) : (
-				<Box flex={1} ref={ref}>
+				<Box
+					flex={1}
+					ref={ref}
+					style={{ opacity: minSize === 0 ? 0 : 1 }}
+				>
 					<PanelGroup direction="horizontal">
 						<Panel
 							defaultSize={minSize}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,16 @@ export default defineConfig(({ mode }) => ({
 				'surrealist': '/index.html',
 				'mini-run': '/mini/run.html',
 				'mini-new': '/mini/new.html'
+			},
+			output: {
+				experimentalMinChunkSize: 5000,
+				manualChunks: {
+					react: ["react", "react-dom"],
+					codemirror: ["codemirror", "codemirror-surrealql", "@replit/codemirror-indentation-markers"],
+					posthog: ["posthog-js"],
+					mantime: ["@mantine/core"],
+					surreal: ["surrealdb.js", "surrealdb.wasm"] // TODO : surrealql.wasm
+				}
 			}
 		},
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig(({ mode }) => ({
 					react: ["react", "react-dom"],
 					codemirror: ["codemirror", "codemirror-surrealql", "@replit/codemirror-indentation-markers"],
 					posthog: ["posthog-js"],
-					mantime: ["@mantine/core"],
+					mantime: ["@mantine/core", "@mantine/hooks", "@mantine/notifications"],
 					surreal: ["surrealdb.js", "surrealdb.wasm"] // TODO : surrealql.wasm
 				}
 			}


### PR DESCRIPTION
Use code-splitting techniques to reduce initial bundle size and to improve startup time performance.

Improvements made:
* lazy import page components (Query view, Explorer view, etc...)
* lazy import of modules, like `lottie-web`. It will be fetched on the main page but after the initial bundles
* lazy import json animated data for lottie

Some notes:
* `elk` can be loaded via web worker, but as it is currently lazy imported when needed, I don't see the need for this
* bundle size reduced by using `lottie-light` instead of `lottie-web`, from 7.27MB to 7.04MB (1.83MB -> 1.79MB gzip)
* some vendors cannot be easily lazy imported (e.g. codemirror) => use `manualChunks` to split each bundle
* splitting in chunks can improve load times by preloading modules in parallel instead of waiting for a single large chunk
* vendor bundles could be cached, if no version upgrade 
* set `experimentalMinChunkSize` to `5000`, having too many small chunks can be bad

Remaining:

* [ ] `icons.tsx` are not splitted, should break icon per each file

Before:

![before](https://github.com/surrealdb/surrealist/assets/6053067/48c4a621-a071-476e-99b5-6b675aba9de5)
![before-bundle-size](https://github.com/surrealdb/surrealist/assets/6053067/079f1ad8-7bd2-4f8b-bb7d-c54d3c59e665)

After:

![after](https://github.com/surrealdb/surrealist/assets/6053067/d3b8be02-ae0a-4af3-bf02-1369f0bef933)
![after-bundle-size](https://github.com/surrealdb/surrealist/assets/6053067/65c68529-e17a-4bc9-bdde-c0281a993478)

