### PR TITLE
Implement Designer view record link visualization

### DIFF
--- a/src/adapter/desktop.tsx
+++ b/src/adapter/desktop.tsx
@@ -303,12 +303,12 @@ export class DesktopAdapter implements SurrealistAdapter {
 		});
 
 		listen("database:output", (event) => {
-			useDatabaseStore.getState().pushConsoleLine(event.payload as string);
-			throttleLevel++;
-
 			if (throttleLevel > 50) {
 				return;
 			}
+
+			useDatabaseStore.getState().pushConsoleLine(event.payload as string);
+			throttleLevel++;
 		});
 
 		listen("database:error", (event) => {

--- a/src/assets/changelogs/2.1.0.md
+++ b/src/assets/changelogs/2.1.0.md
@@ -4,24 +4,29 @@ summary: New features and improvements
 date: TBD
 ---
 
-- Added support for opening .surql or .surrealql files
-- Added support for deeplinking in the desktop app
-- Added query indicator for long lasting queries
+- Added designer view record link visualization
+	- Renders lines for all record<> fields defined on tables
+	- Can be enabled in the designer view options
+- Added support for .surql file opening with Surrealist
+	- Queries are opened as a new tab in the query view
+- Added support for deeplinking to the desktop app
+	- Allows integrating Surrealist deeper into custom tooling and workflows
+- Added a loading indicator for long running queries
 - Added schema function autocompletions in queries
 - Added an appearance setting to permanently expand the sidebar
 - Added Surrealist Mini window messaging protocol
-- Added API docs PHP examples
+- Added PHP examples to the API Docs view
 - Added new convenient query context menu items
 - Added the ability to resize the record creator, inspector, and designer drawers
 - Added a log file for debugging purposes
-- Improved API docs .NET examples
+- Improved .NET examples in the API Docs view
 - Improved Surrealist Mini startup performance for datasets
 - Improved explorer logic and performance
 - Improved the explorer record creation drawer
 - Improved serving console performance
 - Improved database version detection logic
-- Updated SurrealQL syntax highlighting
-- Pretty print the config file on Surrealist Desktop
+- Improved SurrealQL syntax highlighting
+- Improved desktop config file readability
 - Fixed authentication view incorrectly clearing passwords
 - Fixed newsfeed indicator not always dissapearing
 - Fixed certain endpoints getting blocked on MacOS

--- a/src/components/Scaffold/settings/tabs/Appearance.tsx
+++ b/src/components/Scaffold/settings/tabs/Appearance.tsx
@@ -18,9 +18,11 @@ export function AppearanceTab() {
 	const [valueMode, setValueMode] = useSetting(CAT, "valueMode");
 	const [defaultDiagramMode, setDefaultDiagramMode] = useSetting(CAT, "defaultDiagramMode");
 	const [defaultDiagramDirection, setDefaultDiagramDirection] = useSetting(CAT, "defaultDiagramDirection");
+	const [defaultDiagramShowLinks, setDefaultDiagramShowLinks] = useSetting(CAT, "defaultDiagramShowLinks");
 	const [sidebarMode, setSidebarMode] = useSetting(CAT, "sidebarMode");
 
 	const updateResultWordWrap = useCheckbox(setResultWordWrap);
+	const updateDefaultDiagramShowLinks = useCheckbox(setDefaultDiagramShowLinks);
 
 	const [flags] = useFeatureFlags();
 
@@ -130,6 +132,12 @@ export function AppearanceTab() {
 					data={DESIGNER_DIRECTIONS}
 					value={defaultDiagramDirection}
 					onChange={setDefaultDiagramDirection as any}
+				/>
+
+				<Checkbox
+					label="Show links between nodes"
+					checked={defaultDiagramShowLinks}
+					onChange={updateDefaultDiagramShowLinks}
 				/>
 			</SettingsSection>
 		</>

--- a/src/components/Scaffold/settings/tabs/Templates.tsx
+++ b/src/components/Scaffold/settings/tabs/Templates.tsx
@@ -25,6 +25,7 @@ const PLACEHOLDER: Connection = {
 	pinnedTables: [],
 	diagramMode: "fields",
 	diagramDirection: "ltr",
+	diagramShowLinks: false, 
 	queryHistory: []
 };
 

--- a/src/components/Scaffold/settings/utilities.tsx
+++ b/src/components/Scaffold/settings/utilities.tsx
@@ -15,7 +15,7 @@ export function Label(props: PropsWithChildren<TextProps>) {
 
 export function SettingsSection({ label, children }: PropsWithChildren<{ label?: ReactNode }>) {
 	return (
-		<Stack gap="sm">
+		<Stack gap="md">
 			{label && (
 				<Title order={2} c="bright" size={18}>
 					{label}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -72,6 +72,7 @@ export interface Connection {
 	pinnedTables: string[];
 	diagramMode: DiagramMode;
 	diagramDirection: DiagramDirection;
+	diagramShowLinks: boolean;
 	queryHistory: HistoryQuery[];
 }
 
@@ -101,6 +102,7 @@ export interface SurrealistAppearanceSettings {
 	defaultResultMode: ResultMode;
 	defaultDiagramMode: DiagramMode;
 	defaultDiagramDirection: DiagramDirection;
+	defaultDiagramShowLinks: boolean;
 	sidebarMode: SidebarMode;
 	valueMode: ValueMode;
 	queryOrientation: Orientation;

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -44,6 +44,7 @@ export function createBaseSettings(): SurrealistSettings {
 			defaultResultMode: "combined",
 			defaultDiagramMode: "fields",
 			defaultDiagramDirection: "ltr",
+			defaultDiagramShowLinks: false,
 			sidebarMode: "expandable",
 			valueMode: "sql",
 			queryOrientation: "vertical"
@@ -94,6 +95,7 @@ export function createBaseConnection(settings: SurrealistSettings): Connection {
 		queryHistory: [],
 		diagramMode: settings.appearance.defaultDiagramMode,
 		diagramDirection: settings.appearance.defaultDiagramDirection,
+		diagramShowLinks: settings.appearance.defaultDiagramShowLinks
 	};
 }
 

--- a/src/views/designer/TableGraphPane/helpers.tsx
+++ b/src/views/designer/TableGraphPane/helpers.tsx
@@ -45,7 +45,10 @@ function normalizeTables(tables: TableInfo[]): NormalizedTable[] {
 	});
 }
 
-export function buildFlowNodes(tables: TableInfo[]): [Node[], Edge[]] {
+export function buildFlowNodes(
+	tables: TableInfo[],
+	showLinks: boolean
+): [Node[], Edge[]] {
 	const items = normalizeTables(tables);
 	const nodeIndex: Record<string, Node> = {};
 	const edges: Edge[] = [];
@@ -108,25 +111,27 @@ export function buildFlowNodes(tables: TableInfo[]): [Node[], Edge[]] {
 	}
 
 	// Define all record links
-	for (const table of tables) {
-		for (const field of table.fields) {
-			if (!field.kind?.startsWith('record') || field.name == 'in' || field.name == 'out') continue;
+	if (showLinks) {
+		for (const table of tables) {
+			for (const field of table.fields) {
+				if (!field.kind?.startsWith('record') || field.name == 'in' || field.name == 'out') continue;
 
-			const targets = extractKindMeta(field.kind);
+				const targets = extractKindMeta(field.kind);
 
-			for (const target of targets) {
-				if (target == table.schema.name) continue;
+				for (const target of targets) {
+					if (target == table.schema.name) continue;
 
-				edges.push({
-					...EDGE_OPTIONS,
-					id: `tb-${table.schema.name}-field-${field.name}:${target}`,
-					source: table.schema.name,
-					target,
-					className: classes.recordLink,
-					label: field.name,
-					labelShowBg: false,
-					labelStyle: { fill: 'white' }
-				});
+					edges.push({
+						...EDGE_OPTIONS,
+						id: `tb-${table.schema.name}-field-${field.name}:${target}`,
+						source: table.schema.name,
+						target,
+						className: classes.recordLink,
+						label: field.name,
+						labelShowBg: false,
+						labelStyle: { fill: 'white' }
+					});
+				}
 			}
 		}
 	}

--- a/src/views/designer/TableGraphPane/index.tsx
+++ b/src/views/designer/TableGraphPane/index.tsx
@@ -384,7 +384,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 					<HelpTitle isLight={isLight}>Why are edges missing?</HelpTitle>
 
 					<Text mt={8} mb="xl">
-						Surrealist dermines edges by searching for correctly configured <Kbd>in</Kbd> and <Kbd>out</Kbd> fields. You
+						Surrealist only renders edges for tables with a relation type. You
 						can automatically create a new edge table by pressing the <Icon path={iconPlus} /> button on the Table Graph
 						panel. Keep in mind edges are only visible when the layout is set to Diagram.
 					</Text>

--- a/src/views/designer/TableGraphPane/index.tsx
+++ b/src/views/designer/TableGraphPane/index.tsx
@@ -1,9 +1,9 @@
 import classes from "./style.module.scss";
 import { Icon } from "~/components/Icon";
 import { ContentPane } from "~/components/Pane";
-import { ActionIcon, Box, Button, Group, Kbd, Loader, Modal, Popover, Stack, Text, Title, Tooltip } from "@mantine/core";
+import { ActionIcon, Box, Button, Checkbox, Divider, Group, Kbd, Loader, Modal, Popover, Stack, Text, Title, Tooltip } from "@mantine/core";
 import { Background, NodeChange, ReactFlow, useEdgesState, useNodesState, useReactFlow } from "reactflow";
-import { ElementRef, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { ChangeEvent, ElementRef, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { NODE_TYPES, applyNodeLayout, buildFlowNodes, createSnapshot } from "./helpers";
 import { DiagramDirection, DiagramMode, TableInfo } from "~/types";
 import { useStable } from "~/hooks/stable";
@@ -107,7 +107,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 	}, [nodes]);
 
 	const renderGraph = useStable(async () => {
-		const [nodes, edges] = buildFlowNodes(props.tables);
+		const [nodes, edges] = buildFlowNodes(props.tables, activeSession.diagramShowLinks);
 
 		if (nodes.length === 0) {
 			setNodes([]);
@@ -159,8 +159,6 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 			id: activeSession?.id,
 			diagramMode: mode as DiagramMode,
 		});
-
-		renderGraph();
 	});
 
 	const setDiagramDirection = useStable((mode: string) => {
@@ -168,9 +166,18 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 			id: activeSession?.id,
 			diagramDirection: mode as DiagramDirection,
 		});
-
-		renderGraph();
 	});
+
+	const setDiagramShowLinks = useStable((e: ChangeEvent<HTMLInputElement>) => {
+		updateCurrentConnection({
+			id: activeSession?.id,
+			diagramShowLinks: e.target.checked,
+		});
+	});
+
+	useEffect(() => {
+		renderGraph();
+	}, [activeSession.diagramMode, activeSession.diagramDirection, activeSession.diagramShowLinks]);
 
 	useLayoutEffect(() => {
 		if (isViewActive && isConnected) {
@@ -243,6 +250,12 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 									data={DESIGNER_DIRECTIONS}
 									value={activeSession.diagramDirection}
 									onChange={setDiagramDirection}
+								/>
+								<Divider color="slate.6" />
+								<Checkbox
+									label="Show record links"
+									checked={activeSession.diagramShowLinks}
+									onChange={setDiagramShowLinks}
 								/>
 							</Stack>
 						</Popover.Dropdown>

--- a/src/views/designer/TableGraphPane/style.module.scss
+++ b/src/views/designer/TableGraphPane/style.module.scss
@@ -51,9 +51,18 @@
 	}
 
 	:global(.react-flow__edge > path) {
+		stroke-width: 2px;
 		stroke: white !important;
 	}
 
+	:global(.react-flow__edge-textbg) {
+		fill: var(--mantine-color-slate-5);
+	}
+}
+
+:global(.react-flow__edge).record-link path {
+	stroke: var(--mantine-color-slate-5) !important;
+	stroke-dasharray: 5;
 }
 
 :root[data-mantine-color-scheme="light"] .diagram {

--- a/src/views/explorer/ExplorerPane/index.tsx
+++ b/src/views/explorer/ExplorerPane/index.tsx
@@ -199,33 +199,33 @@ export function ExplorerPane({ activeTable, onCreateRecord }: ExplorerPaneProps)
 
 		showContextMenu([
 			{
-				key: "select",
-				title: "Use in SELECT query",
-				icon: <Icon path={iconQuery} />,
-				onClick: () => openRecordQuery(record.id, 'SELECT * FROM')
-			},
-			{
-				key: "select",
-				title: "Use in UPDATE query",
-				icon: <Icon path={iconWrench} />,
-				onClick: () => openRecordQuery(record.id, 'UPDATE')
-			},
-			{
-				key: "select",
-				title: "Use in DELETE query",
-				icon: <Icon path={iconClose} />,
-				onClick: () => openRecordQuery(record.id, 'DELETE')
-			},
-			{
-				key: "divider"
-			},
-			{
 				key: "copy",
 				title: "Copy record id",
 				icon: <Icon path={iconCopy} />,
 				onClick: () => {
 					navigator.clipboard.writeText(formatValue(record.id));
 				}
+			},
+			{
+				key: "divider-1"
+			},
+			{
+				key: "select",
+				title: "Use in SELECT query",
+				onClick: () => openRecordQuery(record.id, 'SELECT * FROM')
+			},
+			{
+				key: "select",
+				title: "Use in UPDATE query",
+				onClick: () => openRecordQuery(record.id, 'UPDATE')
+			},
+			{
+				key: "select",
+				title: "Use in DELETE query",
+				onClick: () => openRecordQuery(record.id, 'DELETE')
+			},
+			{
+				key: "divider-2"
 			},
 			{
 				key: "delete",


### PR DESCRIPTION
Adds a new setting to the designer view to visualize record links between tables

- Disabled by default as it adds significant complexity to the designer graph
- Configurable per connection and new setting to configure default value
- Multiple overlapping links are collapsed into a single line

<img width="1002" alt="image" src="https://github.com/surrealdb/surrealist/assets/7606171/26f79a92-7f08-4a66-9e1c-a74f44376c8c">

closes #100