### PR TITLE
fix: sync document title

### DIFF
--- a/src/adapter/desktop.tsx
+++ b/src/adapter/desktop.tsx
@@ -118,8 +118,8 @@ export class DesktopAdapter implements SurrealistAdapter {
 		"WebView": navigator.userAgent,
 	});
 
-	public async setWindowTitle(title: string) {
-		getCurrent().setTitle(title || "Surrealist");
+	public setWindowTitle(title: string) {
+		return getCurrent().setTitle(title || "Surrealist");
 	}
 
 	public async loadConfig() {

--- a/src/hooks/url.ts
+++ b/src/hooks/url.ts
@@ -7,6 +7,7 @@ import { ViewMode } from "~/types";
 import { IntentEvent } from "~/util/global-events";
 import { useEventSubscription } from "./event";
 import { IntentPayload, IntentType, getIntentView, handleIntentRequest } from "~/util/intents";
+import { updateTitle } from "~/util/helpers";
 
 /**
  * Sync the active view to the URL and handle incoming intents
@@ -46,6 +47,7 @@ export function useUrlHandler() {
 			history.pushState(null, document.title, `/${activeView}`);
 			posthog.capture('$pageview');
 		}
+		updateTitle();
 	}, [activeView]);
 }
 

--- a/src/screens/database/sidebar.tsx
+++ b/src/screens/database/sidebar.tsx
@@ -8,7 +8,6 @@ import { useStable } from "~/hooks/stable";
 import { useConfigStore } from "~/stores/config";
 import { ViewMode } from "~/types";
 import { useFeatureFlags } from "~/util/feature-flags";
-import { updateTitle } from "~/util/helpers";
 import { useIsLight } from "~/hooks/theme";
 import { useConnection } from "~/hooks/connection";
 import { NavigationIcon } from "~/components/NavigationIcon";
@@ -49,7 +48,6 @@ export function DatabaseSidebar({
 	const activeView = useConfigStore((s) => s.activeView);
 
 	const setViewMode = useStable((id: ViewMode) => {
-		updateTitle();
 		setActiveView(id);
 		state.sidebarHandle.close();
 	});


### PR DESCRIPTION
I noticed that the document/window title is never in sync when switching view from the sidebar.