### PR TITLE
fix: typo in query pane

### DIFF
--- a/src/screens/database/views/query/QueryPane/index.tsx
+++ b/src/screens/database/views/query/QueryPane/index.tsx
@@ -127,11 +127,11 @@ export function QueryPane({
 							</ActionIcon>
 						</Tooltip>
 
-						<Tooltip label={`Format ${hasSelection ? "selecion" : "query"}`}>
+						<Tooltip label={`Format ${hasSelection ? "selection" : "query"}`}>
 							<ActionIcon
 								onClick={handleFormat}
 								variant="light"
-								aria-label={`Format ${hasSelection ? "selecion" : "query"}`}
+								aria-label={`Format ${hasSelection ? "selection" : "query"}`}
 							>
 								<Icon path={iconText} />
 							</ActionIcon>


### PR DESCRIPTION
I noticed a small typo in the query pane so I decided to come fix it myself. It used to be 'selecion' and is now 'selection'