### PR TITLE
feat: add format button to function pane

### DIFF
--- a/src/screens/database/views/functions/EditorPanel/index.tsx
+++ b/src/screens/database/views/functions/EditorPanel/index.tsx
@@ -13,12 +13,14 @@ import { SaveableHandle } from "~/hooks/save";
 import { useKindList } from "~/hooks/schema";
 import { useStable } from "~/hooks/stable";
 import { SchemaFunction } from "~/types";
-import { iconCheck, iconCopy, iconDelete, iconDownload, iconJSON, iconPlus } from "~/util/icons";
+import { iconCheck, iconCopy, iconDelete, iconDownload, iconJSON, iconPlus, iconText } from "~/util/icons";
 import { SURQL_FILTER } from "~/constants";
 import { buildFunctionDefinition } from "~/util/schema";
 import { surrealql } from "codemirror-surrealql";
 import { surqlLinting } from "~/util/editor/extensions";
 import { Label } from "~/components/Label";
+import { formatQuery, validateQuery } from "~/util/surrealql";
+import { useEffect } from "react";
 
 export interface EditorPanelProps {
 	handle: SaveableHandle;
@@ -57,6 +59,25 @@ export function EditorPanel({
 		onDelete(details.name);
 	});
 
+	const formatFunction = useStable(() => {
+		console.info('formatting');
+		const isFunctionBlockInvalid = validateQuery(details.block);
+		if (isFunctionBlockInvalid) {
+			console.error(`Unable to format function: ${isFunctionBlockInvalid}`);
+		} else {
+			const formattedFunctionBlock = formatQuery(details.block);
+			onChange((draft) => {
+				draft.block = formattedFunctionBlock;
+			});
+		}
+	});
+
+	// Not sure if this is something we want to do, or if this is how we're supposed to do it
+	// This doesn't end up looking great since the function comes in not formatted, and then quickly gets formatted
+	useEffect(() => {
+		formatFunction();
+	});
+
 	return (
 		<ContentPane
 			title="Function Editor"
@@ -71,6 +92,16 @@ export function EditorPanel({
 					</Badge>
 				)
 			}
+			rightSection={(
+				<Tooltip label="Format function">
+					<ActionIcon
+						onClick={formatFunction}
+						aria-label="Format function"
+					>
+						<Icon path={iconText} />
+					</ActionIcon>
+				</Tooltip>
+			)}
 		>
 			<Group
 				h="100%"


### PR DESCRIPTION
This feature is related to an issue I created (issue #374). I'm working with large functions, and not having a way to format them quickly was causing me some headaches. I decided to put a button to format the function (in the `rightSection` prop of the `ContentPane` in `src/screens/database/views/functions/EditorPanel/index.tsx`). Please note that my initial idea was to format the query using `useEffect` once the function was loaded, but this ended up not looking too great. I left that code in just so you'd see the idea behind that, but I'm totally good with taking it out, or replacing it with another method. Thank you!