### PR TITLE
Fix: light theme

### DIFF
--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -3,12 +3,12 @@ import clsx from "clsx";
 import { Box, BoxProps } from "@mantine/core";
 import { useEffect, useRef } from "react";
 import { useSetting } from "~/hooks/config";
+import { useIsLight } from "~/hooks/theme";
 import { Compartment, EditorState, Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { colorTheme, editorBase } from "~/util/editor/extensions";
 import { forceLinting } from "@codemirror/lint";
 import { history } from "@codemirror/commands";
-import { useIsLight } from "~/hooks/theme";
 
 interface EditorRef {
 	editor: EditorView;
@@ -40,10 +40,10 @@ export function CodeEditor(props: CodeEditorProps) {
 		...rest
 	} = props;
 
+	const isLight = useIsLight();
 	const ref = useRef<HTMLDivElement | null>(null);
 	const editorRef = useRef<EditorRef>();
 	const [editorScale] = useSetting("appearance", "editorScale");
-	const isLight = useIsLight();
 
 	const textSize = Math.floor(15 * (editorScale / 100));
 

--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -5,14 +5,16 @@ import { useEffect, useRef } from "react";
 import { useSetting } from "~/hooks/config";
 import { Compartment, EditorState, Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { editorBase } from "~/util/editor/extensions";
+import { colorTheme, editorBase } from "~/util/editor/extensions";
 import { forceLinting } from "@codemirror/lint";
 import { history } from "@codemirror/commands";
+import { useIsLight } from "~/hooks/theme";
 
 interface EditorRef {
 	editor: EditorView;
 	editable: Compartment;
 	history: Compartment;
+	theme: Compartment;
 }
 
 export interface CodeEditorProps extends BoxProps {
@@ -41,12 +43,14 @@ export function CodeEditor(props: CodeEditorProps) {
 	const ref = useRef<HTMLDivElement | null>(null);
 	const editorRef = useRef<EditorRef>();
 	const [editorScale] = useSetting("appearance", "editorScale");
+	const isLight = useIsLight();
 
 	const textSize = Math.floor(15 * (editorScale / 100));
 
 	useEffect(() => {
 		const editable = new Compartment();
 		const history = new Compartment();
+		const theme = new Compartment();
 		const editableExt = editable.of(EditorState.readOnly.of(!!readOnly));
 		const historyExt = history.of(newHistory());
 
@@ -60,6 +64,7 @@ export function CodeEditor(props: CodeEditorProps) {
 			doc: value,
 			extensions: [
 				editorBase(),
+				theme.of(colorTheme(isLight)),
 				historyExt,
 				changeHandler,
 				editableExt,
@@ -76,7 +81,8 @@ export function CodeEditor(props: CodeEditorProps) {
 		editorRef.current = {
 			editor,
 			editable,
-			history
+			history,
+			theme
 		};
 
 		if (autoFocus) {
@@ -136,6 +142,14 @@ export function CodeEditor(props: CodeEditorProps) {
 			effects: [history.reconfigure([newHistory()])],
 		});
 	}, [historyKey]);
+
+	useEffect(() => {
+		const { editor, theme } = editorRef.current!;
+
+		editor.dispatch({
+			effects: theme.reconfigure(colorTheme(isLight))
+		});
+	}, [isLight]);
 
 	return (
 		<Box

--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -14,6 +14,7 @@ import { iconCheck, iconCopy } from "~/util/icons";
 interface EditorRef {
 	editor: EditorView;
 	config: Compartment;
+	theme: Compartment;
 }
 
 export interface CodePreviewProps extends PaperProps {
@@ -45,12 +46,14 @@ export function CodePreview({
 
 	useEffect(() => {
 		const config = new Compartment();
+		const theme = new Compartment();
 		const configExt = config.of(extensions || surrealql());
 
 		const initialState = EditorState.create({
 			doc: code,
 			extensions: [
 				configExt,
+				theme.of(colorTheme(isLight)),
 				EditorState.readOnly.of(true),
 				EditorView.lineWrapping,
 				EditorView.editable.of(false),
@@ -65,7 +68,8 @@ export function CodePreview({
 
 		editorRef.current = {
 			editor,
-			config
+			config,
+			theme,
 		};
 
 		return () => {
@@ -99,6 +103,14 @@ export function CodePreview({
 			effects: config.reconfigure(extensions || surrealql())
 		});
 	}, [extensions]);
+
+	useEffect(() => {
+		const { editor, theme } = editorRef.current!;
+
+		editor.dispatch({
+			effects: theme.reconfigure(colorTheme(isLight))
+		});
+	}, [isLight]);
 
 	return (
 		<>

--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -51,7 +51,6 @@ export function CodePreview({
 			doc: code,
 			extensions: [
 				configExt,
-				colorTheme(),
 				EditorState.readOnly.of(true),
 				EditorView.lineWrapping,
 				EditorView.editable.of(false),

--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -80,7 +80,13 @@ export function CodeInput({
 			parent: ref.current!,
 		});
 
-		editorRef.current = { editor, editable, fallback, keymaps, theme };
+		editorRef.current = {
+			editor,
+			editable,
+			fallback,
+			keymaps,
+			theme,
+		};
 
 		if (autoFocus) {
 			const timer = setInterval(() => {

--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -4,10 +4,11 @@ import { surrealql } from "codemirror-surrealql";
 import { ActionIcon, Autocomplete, AutocompleteProps, Group, InputBase, InputBaseProps, Tooltip } from "@mantine/core";
 import { HTMLAttributes, useEffect, useMemo, useRef } from "react";
 import { Icon } from "~/components/Icon";
+import { useIsLight } from "~/hooks/theme";
 import { useStable } from "~/hooks/stable";
 import { useKindList } from "~/hooks/schema";
 import { iconCancel, iconCheck } from "~/util/icons";
-import { inputBase } from "~/util/editor/extensions";
+import { colorTheme, inputBase } from "~/util/editor/extensions";
 import { EditorView, keymap, placeholder as ph } from "@codemirror/view";
 import { Compartment, EditorState, Extension, Prec } from "@codemirror/state";
 import { acceptWithTab } from "~/util/editor/keybinds";
@@ -35,18 +36,21 @@ export function CodeInput({
 	onSubmit,
 	...rest
 }: CodeInputProps) {
+	const isLight = useIsLight();
 	const ref = useRef<HTMLDivElement | null>(null);
 	const editorRef = useRef<{
 		editor: EditorView;
 		editable: Compartment;
 		fallback: Compartment;
 		keymaps: Compartment;
+		theme: Compartment;
 	}>();
 
 	useEffect(() => {
 		const editable = new Compartment();
 		const fallback = new Compartment();
 		const keymaps = new Compartment();
+		const theme = new Compartment();
 
 		const editableExt = editable.of(EditorState.readOnly.of(!!disabled));
 		const fallbackExt = fallback.of(placeholder ? ph(placeholder) : []);
@@ -62,6 +66,7 @@ export function CodeInput({
 			doc: value,
 			extensions: [
 				inputBase(),
+				colorTheme(isLight),
 				extensions || surrealql(),
 				changeHandler,
 				editableExt,
@@ -72,10 +77,10 @@ export function CodeInput({
 
 		const editor = new EditorView({
 			state: initialState,
-			parent: ref.current!
+			parent: ref.current!,
 		});
 
-		editorRef.current = { editor, editable, fallback, keymaps };
+		editorRef.current = { editor, editable, fallback, keymaps, theme };
 
 		if (autoFocus) {
 			const timer = setInterval(() => {
@@ -146,6 +151,14 @@ export function CodeInput({
 		});
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [multiline]);
+
+	useEffect(() => {
+		const { editor, theme } = editorRef.current!;
+
+		editor.dispatch({
+			effects: theme.reconfigure(colorTheme(isLight))
+		});
+	}, [isLight]);
 
 	return (
 		<InputBase

--- a/src/util/editor/extensions.tsx
+++ b/src/util/editor/extensions.tsx
@@ -21,10 +21,8 @@ type RecordLinkCallback = (link: string) => void;
 /**
  * The color scheme used within editors
  */
-export const colorTheme = () => [
-	syntaxHighlighting(DARK_STYLE, { fallback: true }),
-	syntaxHighlighting(LIGHT_STYLE, { fallback: true }),
-];
+export const colorTheme = (isLight?: boolean) =>
+	syntaxHighlighting(isLight ? LIGHT_STYLE : DARK_STYLE, { fallback: true });
 
 /**
  * Shared base configuration for all dedicated editors
@@ -43,7 +41,6 @@ export const editorBase = (): Extension => [
 	autocompletion(),
 	rectangularSelection(),
 	crosshairCursor(),
-	colorTheme(),
 	indentationMarkers({
 		colors: {
 			light: themeColor('slate'),
@@ -82,7 +79,6 @@ export const inputBase = (): Extension => [
 	indentOnInput(),
 	bracketMatching(),
 	closeBrackets(),
-	colorTheme(),
 	keymap.of([
 		...closeBracketsKeymap,
 		...customHistoryKeymap,


### PR DESCRIPTION
Closes https://github.com/surrealdb/surrealist/issues/340

Theme in terms of "dark" or "light" doesn't seem to work well with CodeMirror - for some reason `themeType` is not set as state, but based on what theme extension was added (if I understand codemirror source correctly).

That's why I refactored theme into it's own `Compartment`.