### PR TITLE
fix: default field permission

### DIFF
--- a/src/screens/database/views/designer/DesignDrawer/elements/fields.tsx
+++ b/src/screens/database/views/designer/DesignDrawer/elements/fields.tsx
@@ -20,10 +20,10 @@ export function FieldsElement({ data, setData }: ElementProps) {
 				value: "",
 				default: "",
 				permissions: {
-					create: "FULL",
-					select: "FULL",
-					update: "FULL",
-					delete: "FULL",
+					create: true,
+					select: true,
+					update: true,
+					delete: true,
 				},
 			});
 		});


### PR DESCRIPTION
Fixes #383

Any string passed as a permission is interpreted as a condition and 'WHERE' clause is required.

`'FULL'` and `'NONE'` are not conditions, boolean value is used to represent them and 'WHERE' is not included in the query accordingly, this is checked here during query build process.
https://github.com/surrealdb/surrealist/blob/1809db570de9a8acf6c4cee5bfc9953b0be45b1a/src/screens/database/views/designer/DesignDrawer/helpers.tsx#L29-L31

The UI makes sure to set `value` to `true`/`false` if `'FULL'`/`'NONE'` is typed in the permissions textField of the UI in addition to the checking above.
https://github.com/surrealdb/surrealist/blob/7f191906170dad97c8b7fee93601db571a4107df/src/components/Inputs/index.tsx#L200-L206

If no editing in permissions happen when creating a field, `'FULL'` is not changed to `true` and is returned as is.
`'FULL'` is not expected in other parts of code, it is considered as a condition resulting in incorrect permissions such as 'WHERE FULL'

Using only string to represent the permission is not feasible.
Decided to change the initial values to 'true' as the optimal fix.

This removes the possibility of `'FULL'` being returned, `true` is returned instead when no change is made.

Tested manually.