### PR TITLE
feat: save config in indexeddb

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"geo-coordinates-parser": "^1.7.0",
 		"graphql": "^16.9.0",
 		"html-to-image": "^1.11.11",
+		"idb": "^8.0.0",
 		"immer": "^10.0.2",
 		"klona": "^2.0.6",
 		"leaflet": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       html-to-image:
         specifier: ^1.11.11
         version: 1.11.11
+      idb:
+        specifier: ^8.0.0
+        version: 8.0.0
       immer:
         specifier: ^10.0.2
         version: 10.1.1
@@ -2198,6 +2201,9 @@ packages:
   http2-wrapper@2.2.1:
     resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
     engines: {node: '>=10.19.0'}
+
+  idb@8.0.0:
+    resolution: {integrity: sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==}
 
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
@@ -4945,6 +4951,8 @@ snapshots:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
+
+  idb@8.0.0: {}
 
   immer@10.1.1: {}
 

--- a/src/util/idxdb.ts
+++ b/src/util/idxdb.ts
@@ -1,0 +1,21 @@
+import { openDB } from "idb";
+import { CONFIG_KEY } from "./storage";
+
+const dbName = "surrealist";
+const indexedDbVersion = 1;
+const keyValueStore = "store";
+
+const dbPromise = openDB(dbName, indexedDbVersion, {
+	upgrade(db) {
+		db.createObjectStore(keyValueStore);
+	},
+});
+
+async function getConfig() {
+	return (await dbPromise).get(keyValueStore, CONFIG_KEY);
+}
+async function setConfig(value: any) {
+	return (await dbPromise).put(keyValueStore, value, CONFIG_KEY);
+}
+
+export { getConfig, setConfig };

--- a/src/util/storage.tsx
+++ b/src/util/storage.tsx
@@ -3,3 +3,4 @@ export const STATE_RES_KEY = "surrealist:oauth_response_state";
 export const VERIFIER_KEY = "surrealist:oauth_verifier";
 export const REFRESH_TOKEN_KEY = "surrealist:oauth_refresh_token";
 export const STATE_KEY = "surrealist:oauth_state";
+export const CONFIG_KEY = "surrealist:config";


### PR DESCRIPTION
* save config in IndexedDb to avoid storage constraint and improve app performance (async storage)
* simple transition from localstorage to IndexedDb
* use `idb` package to simplify IndexedDb usage (1.2kB gzipped)