### PR TITLE
Change/elk based pathing for edges

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
 	"version": "3.0.8",
 	"surreal": "2.0.0",
 	"type": "module",
-	"authors": ["SurrealDB"],
+	"authors": [
+		"SurrealDB"
+	],
 	"scripts": {
 		"build": "tsc && vite build",
 		"build:desktop": "tsc && vite build -c vite.config.desktop.ts",
@@ -63,6 +65,7 @@
 		"@tauri-apps/plugin-shell": "2.0.0-rc.1",
 		"@tauri-apps/plugin-updater": "2.0.0-rc.2",
 		"@theopensource-company/feature-flags": "^0.4.6",
+		"@xyflow/react": "^12.3.2",
 		"ansi-to-html": "^0.7.2",
 		"clsx": "^2.1.0",
 		"cm6-graphql": "^0.1.1",
@@ -90,7 +93,6 @@
 		"react-leaflet": "^4.2.1",
 		"react-resizable-panels": "^2.0.5",
 		"react-reverse-portal": "^2.1.1",
-		"reactflow": "^11.10.4",
 		"rss-parser": "^3.13.0",
 		"surrealdb": "^1.0.4",
 		"use-immer": "^0.9.0",
@@ -118,7 +120,6 @@
 	},
 	"pnpm": {
 		"patchedDependencies": {
-			"@reactflow/core@11.11.4": "patches/@reactflow__core@11.11.4.patch",
 			"graphql@16.9.0": "patches/graphql@16.9.0.patch"
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@reactflow/core@11.11.4':
-    hash: tj4jyedi5a5rqdyerfsnn6pgdu
-    path: patches/@reactflow__core@11.11.4.patch
   graphql@16.9.0:
     hash: ld77r6ldo77drpc37fyutqbsa4
     path: patches/graphql@16.9.0.patch
@@ -136,6 +133,9 @@ importers:
       '@theopensource-company/feature-flags':
         specifier: ^0.4.6
         version: 0.4.6(typescript@5.5.4)
+      '@xyflow/react':
+        specifier: ^12.3.2
+        version: 12.3.2(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ansi-to-html:
         specifier: ^0.7.2
         version: 0.7.2
@@ -217,9 +217,6 @@ importers:
       react-reverse-portal:
         specifier: ^2.1.1
         version: 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      reactflow:
-        specifier: ^11.10.4
-        version: 11.11.4(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rss-parser:
         specifier: ^3.13.0
         version: 3.13.0
@@ -1370,42 +1367,6 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@reactflow/background@11.3.14':
-    resolution: {integrity: sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/controls@11.2.14':
-    resolution: {integrity: sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/core@11.11.4':
-    resolution: {integrity: sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/minimap@11.7.14':
-    resolution: {integrity: sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/node-resizer@2.2.14':
-    resolution: {integrity: sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/node-toolbar@1.3.14':
-    resolution: {integrity: sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
   '@replit/codemirror-indentation-markers@6.5.3':
     resolution: {integrity: sha512-hL5Sfvw3C1vgg7GolLe/uxX5T3tmgOA3ZzqlMv47zjU1ON51pzNWiVbS22oh6crYhtVhv8b3gdXwoYp++2ilHw==}
     peerDependencies:
@@ -1589,8 +1550,8 @@ packages:
   '@surrealdb/codemirror@1.0.0-beta.11':
     resolution: {integrity: sha512-JB9wCTZvummpg3SYQ2cnA52LJqzJnextK3vuW33jTv4tU1wY2LFqbgn8JWgOYeNWyp7J1h5HgNCkBoN8dlAUYQ==}
 
-  '@surrealdb/lezer@1.0.0-beta.11':
-    resolution: {integrity: sha512-otcbmbbAvLTebHqX1wReRTFLULBWej1fpSeCF6TMzsJiR4qDnaz8RXmZeLJbGrYptXthoBxJQKSaoh8M8+diCw==}
+  '@surrealdb/lezer@1.0.0-beta.12':
+    resolution: {integrity: sha512-/bG3VLkh9d+lddh5Jcqs7GNj/NTVZxsnpt0PKNqaPIue9Dmtzxd/vysZGgxQRcNbR8+sTjWZgjYQfGKMwERGzA==}
 
   '@surrealdb/lezer@1.0.0-beta.5':
     resolution: {integrity: sha512-sz9ZmLwtYVtOsyY7B2bZJk8z/OWLkSoWmZxKz0uqaAnr4ccqV9uesKuu3/fPRsxgOc5ZzeOUlMnxbPJfeMtgLA==}
@@ -1729,98 +1690,23 @@ packages:
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
-  '@types/d3-array@3.2.1':
-    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
-
-  '@types/d3-axis@3.0.6':
-    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
-
-  '@types/d3-brush@3.0.6':
-    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
-
-  '@types/d3-chord@3.0.6':
-    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
-
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
-
-  '@types/d3-contour@3.0.6':
-    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
-
-  '@types/d3-delaunay@6.0.4':
-    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
-
-  '@types/d3-dispatch@3.0.6':
-    resolution: {integrity: sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
-  '@types/d3-dsv@3.0.7':
-    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
-
-  '@types/d3-ease@3.0.2':
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
-
-  '@types/d3-fetch@3.0.7':
-    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
-
-  '@types/d3-force@3.0.10':
-    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
-
-  '@types/d3-format@3.0.4':
-    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
-
-  '@types/d3-geo@3.1.0':
-    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
-
-  '@types/d3-hierarchy@3.1.7':
-    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
-
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
-  '@types/d3-path@3.1.0':
-    resolution: {integrity: sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==}
-
-  '@types/d3-polygon@3.0.2':
-    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
-
-  '@types/d3-quadtree@3.0.6':
-    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
-
-  '@types/d3-random@3.0.3':
-    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
-
-  '@types/d3-scale-chromatic@3.0.3':
-    resolution: {integrity: sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw==}
-
-  '@types/d3-scale@4.0.8':
-    resolution: {integrity: sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==}
-
   '@types/d3-selection@3.0.10':
     resolution: {integrity: sha512-cuHoUgS/V3hLdjJOLTT691+G2QoqAjCVLmr4kJXR4ha56w1Zdu8UUQ5TxLRqudgNjwXeQxKMq4j+lyf9sWuslg==}
-
-  '@types/d3-shape@3.1.6':
-    resolution: {integrity: sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==}
-
-  '@types/d3-time-format@4.0.3':
-    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
-
-  '@types/d3-time@3.0.3':
-    resolution: {integrity: sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==}
-
-  '@types/d3-timer@3.0.2':
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/d3-transition@3.0.8':
     resolution: {integrity: sha512-ew63aJfQ/ms7QQ4X7pk5NxQ9fZH/z+i24ZfJ6tJSfqxJMrYLiK01EAs2/Rtw/JreGUsS3pLPNV644qXFGnoZNQ==}
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
-
-  '@types/d3@7.4.3':
-    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -1890,6 +1776,15 @@ packages:
 
   '@vue/shared@3.4.38':
     resolution: {integrity: sha512-q0xCiLkuWWQLzVrecPb0RMsNWyxICOjPrcrwxTUEHb1fsnvni4dcuyG7RT/Ie7VPTvnjzIaWzRMUBsrqNj/hhw==}
+
+  '@xyflow/react@12.3.2':
+    resolution: {integrity: sha512-+bK3L61BDIvUX++jMiEqIjy5hIIyVmfeiUavpeOZIYKwg6NW0pR5EnHJM2JFfkVqZisFauzS9EgmI+tvTqx9Qw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.43':
+    resolution: {integrity: sha512-1zHgad1cWr1mKm2xbFaarK0Jg8WRgaQ8ubSBIo/pRdq3fEgCuqgNkL9NSAP6Rvm8zi3+Lu4JPUMN+EEx5QgX9A==}
 
   acorn@8.12.1:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
@@ -2613,12 +2508,6 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
-
-  reactflow@11.11.4:
-    resolution: {integrity: sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -4224,84 +4113,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@reactflow/background@11.3.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@reactflow/core': 11.11.4(patch_hash=tj4jyedi5a5rqdyerfsnn6pgdu)(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      classcat: 5.0.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/controls@11.2.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@reactflow/core': 11.11.4(patch_hash=tj4jyedi5a5rqdyerfsnn6pgdu)(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      classcat: 5.0.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/core@11.11.4(patch_hash=tj4jyedi5a5rqdyerfsnn6pgdu)(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@types/d3': 7.4.3
-      '@types/d3-drag': 3.0.7
-      '@types/d3-selection': 3.0.10
-      '@types/d3-zoom': 3.0.8
-      classcat: 5.0.5
-      d3-drag: 3.0.0
-      d3-selection: 3.0.0
-      d3-zoom: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/minimap@11.7.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@reactflow/core': 11.11.4(patch_hash=tj4jyedi5a5rqdyerfsnn6pgdu)(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/d3-selection': 3.0.10
-      '@types/d3-zoom': 3.0.8
-      classcat: 5.0.5
-      d3-selection: 3.0.0
-      d3-zoom: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/node-resizer@2.2.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@reactflow/core': 11.11.4(patch_hash=tj4jyedi5a5rqdyerfsnn6pgdu)(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      classcat: 5.0.5
-      d3-drag: 3.0.0
-      d3-selection: 3.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/node-toolbar@1.3.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@reactflow/core': 11.11.4(patch_hash=tj4jyedi5a5rqdyerfsnn6pgdu)(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      classcat: 5.0.5
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
   '@replit/codemirror-indentation-markers@6.5.3(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.33.0)':
     dependencies:
       '@codemirror/language': 6.10.2
@@ -4419,9 +4230,9 @@ snapshots:
       '@codemirror/language': 6.10.2
       '@lezer/common': 1.2.1
       '@lezer/javascript': 1.4.18
-      '@surrealdb/lezer': 1.0.0-beta.11
+      '@surrealdb/lezer': 1.0.0-beta.12
 
-  '@surrealdb/lezer@1.0.0-beta.11':
+  '@surrealdb/lezer@1.0.0-beta.12':
     dependencies:
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -4560,80 +4371,17 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.4
 
-  '@types/d3-array@3.2.1': {}
-
-  '@types/d3-axis@3.0.6':
-    dependencies:
-      '@types/d3-selection': 3.0.10
-
-  '@types/d3-brush@3.0.6':
-    dependencies:
-      '@types/d3-selection': 3.0.10
-
-  '@types/d3-chord@3.0.6': {}
-
   '@types/d3-color@3.1.3': {}
-
-  '@types/d3-contour@3.0.6':
-    dependencies:
-      '@types/d3-array': 3.2.1
-      '@types/geojson': 7946.0.14
-
-  '@types/d3-delaunay@6.0.4': {}
-
-  '@types/d3-dispatch@3.0.6': {}
 
   '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.10
 
-  '@types/d3-dsv@3.0.7': {}
-
-  '@types/d3-ease@3.0.2': {}
-
-  '@types/d3-fetch@3.0.7':
-    dependencies:
-      '@types/d3-dsv': 3.0.7
-
-  '@types/d3-force@3.0.10': {}
-
-  '@types/d3-format@3.0.4': {}
-
-  '@types/d3-geo@3.1.0':
-    dependencies:
-      '@types/geojson': 7946.0.14
-
-  '@types/d3-hierarchy@3.1.7': {}
-
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
 
-  '@types/d3-path@3.1.0': {}
-
-  '@types/d3-polygon@3.0.2': {}
-
-  '@types/d3-quadtree@3.0.6': {}
-
-  '@types/d3-random@3.0.3': {}
-
-  '@types/d3-scale-chromatic@3.0.3': {}
-
-  '@types/d3-scale@4.0.8':
-    dependencies:
-      '@types/d3-time': 3.0.3
-
   '@types/d3-selection@3.0.10': {}
-
-  '@types/d3-shape@3.1.6':
-    dependencies:
-      '@types/d3-path': 3.1.0
-
-  '@types/d3-time-format@4.0.3': {}
-
-  '@types/d3-time@3.0.3': {}
-
-  '@types/d3-timer@3.0.2': {}
 
   '@types/d3-transition@3.0.8':
     dependencies:
@@ -4643,39 +4391,6 @@ snapshots:
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.10
-
-  '@types/d3@7.4.3':
-    dependencies:
-      '@types/d3-array': 3.2.1
-      '@types/d3-axis': 3.0.6
-      '@types/d3-brush': 3.0.6
-      '@types/d3-chord': 3.0.6
-      '@types/d3-color': 3.1.3
-      '@types/d3-contour': 3.0.6
-      '@types/d3-delaunay': 6.0.4
-      '@types/d3-dispatch': 3.0.6
-      '@types/d3-drag': 3.0.7
-      '@types/d3-dsv': 3.0.7
-      '@types/d3-ease': 3.0.2
-      '@types/d3-fetch': 3.0.7
-      '@types/d3-force': 3.0.10
-      '@types/d3-format': 3.0.4
-      '@types/d3-geo': 3.1.0
-      '@types/d3-hierarchy': 3.1.7
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-path': 3.1.0
-      '@types/d3-polygon': 3.0.2
-      '@types/d3-quadtree': 3.0.6
-      '@types/d3-random': 3.0.3
-      '@types/d3-scale': 4.0.8
-      '@types/d3-scale-chromatic': 3.0.3
-      '@types/d3-selection': 3.0.10
-      '@types/d3-shape': 3.1.6
-      '@types/d3-time': 3.0.3
-      '@types/d3-time-format': 4.0.3
-      '@types/d3-timer': 3.0.2
-      '@types/d3-transition': 3.0.8
-      '@types/d3-zoom': 3.0.8
 
   '@types/estree@1.0.5': {}
 
@@ -4785,6 +4500,27 @@ snapshots:
       vue: 3.4.38(typescript@5.5.4)
 
   '@vue/shared@3.4.38': {}
+
+  '@xyflow/react@12.3.2(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@xyflow/system': 0.0.43
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.5(@types/react@18.3.4)(immer@10.1.1)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.43':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-selection': 3.0.10
+      '@types/d3-transition': 3.0.8
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
 
   acorn@8.12.1: {}
 
@@ -5489,20 +5225,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  reactflow@11.11.4(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@reactflow/background': 11.3.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/controls': 11.2.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/core': 11.11.4(patch_hash=tj4jyedi5a5rqdyerfsnn6pgdu)(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/minimap': 11.7.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/node-resizer': 2.2.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reactflow/node-toolbar': 1.3.14(@types/react@18.3.4)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
 
   readdirp@3.6.0:
     dependencies:

--- a/src/components/App/hooks/window.tsx
+++ b/src/components/App/hooks/window.tsx
@@ -1,22 +1,13 @@
-import { clamp } from "reactflow";
 import { useSetting } from "~/hooks/config";
 import { useKeymap } from "~/hooks/keymap";
 import { useStable } from "~/hooks/stable";
 import { useIntent } from "~/hooks/url";
+import { clamp } from "~/util/helpers";
 
 export function useWindowSettings() {
-	const [windowScale, setWindowScale] = useSetting(
-		"appearance",
-		"windowScale",
-	);
-	const [editorScale, setEditorScale] = useSetting(
-		"appearance",
-		"editorScale",
-	);
-	const [windowPinned, setWindowPinned] = useSetting(
-		"behavior",
-		"windowPinned",
-	);
+	const [windowScale, setWindowScale] = useSetting("appearance", "windowScale");
+	const [editorScale, setEditorScale] = useSetting("appearance", "editorScale");
+	const [windowPinned, setWindowPinned] = useSetting("behavior", "windowPinned");
 
 	const increaseWindowScale = useStable(() => {
 		setWindowScale(clamp(windowScale + 10, 75, 150));

--- a/src/screens/database/views/designer/DesignerView/index.tsx
+++ b/src/screens/database/views/designer/DesignerView/index.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mantine/core";
+import { ReactFlowProvider } from "@xyflow/react";
 import { memo, useEffect } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
-import { ReactFlowProvider } from "@xyflow/react";
 import { Icon } from "~/components/Icon";
 import { PanelDragger } from "~/components/Pane/dragger";
 import { useActiveConnection, useIsConnected } from "~/hooks/connection";

--- a/src/screens/database/views/designer/DesignerView/index.tsx
+++ b/src/screens/database/views/designer/DesignerView/index.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mantine/core";
 import { memo, useEffect } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
-import { ReactFlowProvider } from "reactflow";
+import { ReactFlowProvider } from "@xyflow/react";
 import { Icon } from "~/components/Icon";
 import { PanelDragger } from "~/components/Pane/dragger";
 import { useActiveConnection, useIsConnected } from "~/hooks/connection";
@@ -52,7 +52,10 @@ export function DesignerView() {
 
 	return (
 		<>
-			<Box h="100%" ref={ref}>
+			<Box
+				h="100%"
+				ref={ref}
+			>
 				<PanelGroup
 					direction="horizontal"
 					style={{ opacity: minSize === 0 ? 0 : 1 }}
@@ -75,7 +78,10 @@ export function DesignerView() {
 							<PanelDragger />
 						</>
 					)}
-					<Panel minSize={minSize} order={2}>
+					<Panel
+						minSize={minSize}
+						order={2}
+					>
 						<ReactFlowProvider>
 							<TableGraphPaneLazy
 								tables={tables}

--- a/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -25,6 +25,9 @@ export function ElkStepEdge({
 		}
 
 		const bends: string = bendSection.bendPoints?.map((v, index, arr) => {
+			const minBendRadius = 8;
+			const maxBendRadius = 36;
+
 			const lastSection = arr[index - 1] ?? bendSection.startPoint;
 			const nextSection = arr[index + 1] ?? bendSection.endPoint;
 
@@ -32,9 +35,7 @@ export function ElkStepEdge({
 			const nextLength = Math.max(Math.abs(nextSection.x - v.x), Math.abs(nextSection.y - v.y));
 
 			const _bend = Math.min(lastLength, nextLength) / 2;
-			const maxBendRadius = 36;
-
-			const bendRadius = _bend < maxBendRadius ? _bend : maxBendRadius;
+			const bendRadius = Math.max(Math.min(_bend, maxBendRadius), minBendRadius);
 
 			if (
 				v.x === lastSection.x &&

--- a/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from "react";
 import { BaseEdge, type Edge, type EdgeProps, SmoothStepEdge } from "@xyflow/react";
 import type { ElkEdgeSection } from "elkjs/lib/elk-api";
+import { useMemo } from "react";
 
 export type ElkEdge = Edge<
 	{

--- a/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
-import { BaseEdge, EdgeProps, SmoothStepEdge } from "reactflow";
+import { BaseEdge, type EdgeProps, SmoothStepEdge } from "reactflow";
 
-interface EdgeData extends Object {
+interface EdgeData extends Record<string, any> {
 	data: any;
 	elkData?: {
 		bendSections: import("elkjs/lib/elk.bundled").ElkEdgeSection[];
@@ -17,7 +17,7 @@ export function ElkStepEdge({
 	data,
 	...rest
 }: EdgeProps<EdgeData>) {
-	const bendSection = useMemo(() => !!data?.elkData?.bendSections ? data.elkData.bendSections[0] : undefined, [data?.elkData?.bendSections]);
+	const bendSection = useMemo(() => data?.elkData?.bendSections ? data.elkData.bendSections[0] : undefined, [data?.elkData?.bendSections]);
 
 	const edgePath = useMemo(() => {
 		if (!bendSection) {
@@ -65,7 +65,9 @@ export function ElkStepEdge({
 
 				// From the top
 				return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
-			} else if (
+			}
+
+			if (
 				currentRounded.x === lastRounded.x &&
 				nextRounded.x < currentRounded.x
 			) {
@@ -77,7 +79,9 @@ export function ElkStepEdge({
 
 				// From the top
 				return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
-			} else if (
+			}
+
+			if (
 				currentRounded.y === lastRounded.y &&
 				nextRounded.y > currentRounded.y
 			) {
@@ -89,7 +93,9 @@ export function ElkStepEdge({
 
 				// From the left
 				return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
-			} else if (
+			}
+
+			if (
 				currentRounded.y === lastRounded.y &&
 				nextRounded.y < currentRounded.y
 			) {
@@ -109,7 +115,7 @@ export function ElkStepEdge({
 		}).join(' ') || "";
 
 		return `M${bendSection.startPoint.x},${bendSection.startPoint.y} ${bends} L${bendSection.endPoint.x},${bendSection.endPoint.y}`;
-	}, [bendSection]);
+	}, [bendSection, sourceX, sourceY, targetX, targetY]);
 
 	const labelPosition = useMemo(() => {
 		if (!bendSection) {
@@ -135,7 +141,7 @@ export function ElkStepEdge({
 		}
 
 		return position;
-	}, [bendSection]);
+	}, [bendSection, sourceX, sourceY, targetX, targetY]);
 
 	if (!bendSection || data?.elkData?.isDragged) {
 		return (

--- a/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -37,51 +37,73 @@ export function ElkStepEdge({
 			const _bend = Math.min(lastLength, nextLength) / 2;
 			const bendRadius = Math.max(Math.min(_bend, maxBendRadius), minBendRadius);
 
+			// NOTE: values are rounded because the values can differ by a very small amount
+			const lastRounded = {
+				x: Math.round(lastSection.x),
+				y: Math.round(lastSection.y),
+			};
+
+			const currentRounded = {
+				x: Math.round(v.x),
+				y: Math.round(v.y),
+			}
+
+			const nextRounded = {
+				x: Math.round(nextSection.x),
+				y: Math.round(nextSection.y),
+			};
+
 			if (
-				v.x === lastSection.x &&
-				nextSection.x > v.x
+				currentRounded.x === lastRounded.x &&
+				nextRounded.x > currentRounded.x
 			) {
-				if (v.y < lastSection.y) {
-					// bends to the right from the bottom
+				// Bend to the right
+				if (lastRounded.y > currentRounded.y) {
+					// From the bottom
 					return `L${v.x},${v.y + bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
 				}
 
-				// bends to the right from the top
+				// From the top
 				return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
 			} else if (
-				v.x === lastSection.x &&
-				nextSection.x < v.x
+				currentRounded.x === lastRounded.x &&
+				nextRounded.x < currentRounded.x
 			) {
-				if (v.y < lastSection.y) {
-					// bends to the left from the bottom
+				// Bend to the left
+				if (lastRounded.y > currentRounded.y) {
+					// From the bottom
 					return `L${v.x},${v.y + bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
 				}
 
-				// bends to the left from the top
+				// From the top
 				return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
 			} else if (
-				v.y === lastSection.y &&
-				nextSection.y > v.y
+				currentRounded.y === lastRounded.y &&
+				nextRounded.y > currentRounded.y
 			) {
-				if (v.x < lastSection.x) {
-					// bends down from the right
+				// Bend to the bottom
+				if (lastRounded.x > currentRounded.x) {
+					// From the right
 					return `L${v.x + bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
 				}
 
-				// bends down from the left
+				// From the left
 				return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
 			} else if (
-				v.y === lastSection.y &&
-				nextSection.y < v.y
+				currentRounded.y === lastRounded.y &&
+				nextRounded.y < currentRounded.y
 			) {
-				if (v.x < lastSection.x) {
-					// bends up from the right
+				// Bend to the top
+				if (lastRounded.x > currentRounded.x) {
+					// From the right
 					return `L${v.x + bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y - bendRadius}`;
 				}
 
-				// bends up from the left
+				// From the left
 				return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y - bendRadius}`;
 			}
+
+			console.error("Unknown bend direction", lastRounded, currentRounded, nextRounded);
 
 			return `L${v.x},${v.y}`;
 		}).join(' ') || "";

--- a/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -1,13 +1,6 @@
 import { useMemo } from "react";
 import { BaseEdge, type EdgeProps, SmoothStepEdge } from "reactflow";
-
-interface EdgeData extends Record<string, any> {
-	data: any;
-	elkData?: {
-		bendSections: import("elkjs/lib/elk.bundled").ElkEdgeSection[];
-		isDragged: boolean;
-	}
-}
+import type { EdgeData } from "../helpers";
 
 export function ElkStepEdge({
 	sourceX,
@@ -17,102 +10,104 @@ export function ElkStepEdge({
 	data,
 	...rest
 }: EdgeProps<EdgeData>) {
-	const bendSection = useMemo(() => data?.elkData?.bendSections ? data.elkData.bendSections[0] : undefined, [data?.elkData?.bendSections]);
+	const bendSection = data?.path;
 
 	const edgePath = useMemo(() => {
 		if (!bendSection) {
 			return `M${sourceX},${sourceY} L${targetX},${targetY}`;
 		}
 
-		const bends: string = bendSection.bendPoints?.map((v, index, arr) => {
-			const minBendRadius = 8;
-			const maxBendRadius = 36;
+		const bends: string =
+			bendSection.bendPoints
+				?.map((v, index, arr) => {
+					const minBendRadius = 8;
+					const maxBendRadius = 36;
 
-			const lastSection = arr[index - 1] ?? bendSection.startPoint;
-			const nextSection = arr[index + 1] ?? bendSection.endPoint;
+					const lastSection = arr[index - 1] ?? bendSection.startPoint;
+					const nextSection = arr[index + 1] ?? bendSection.endPoint;
 
-			const lastLength = Math.max(Math.abs(lastSection.x - v.x), Math.abs(lastSection.y - v.y));
-			const nextLength = Math.max(Math.abs(nextSection.x - v.x), Math.abs(nextSection.y - v.y));
+					const lastLength = Math.max(
+						Math.abs(lastSection.x - v.x),
+						Math.abs(lastSection.y - v.y),
+					);
+					const nextLength = Math.max(
+						Math.abs(nextSection.x - v.x),
+						Math.abs(nextSection.y - v.y),
+					);
 
-			const _bend = Math.min(lastLength, nextLength) / 2;
-			const bendRadius = Math.max(Math.min(_bend, maxBendRadius), minBendRadius);
+					const _bend = Math.min(lastLength, nextLength) / 2;
+					const bendRadius = Math.max(Math.min(_bend, maxBendRadius), minBendRadius);
 
-			// NOTE: values are rounded because the values can differ by a very small amount
-			const lastRounded = {
-				x: Math.round(lastSection.x),
-				y: Math.round(lastSection.y),
-			};
+					// NOTE: values are rounded because the values can differ by a very small amount
+					const lastRounded = {
+						x: Math.round(lastSection.x),
+						y: Math.round(lastSection.y),
+					};
 
-			const currentRounded = {
-				x: Math.round(v.x),
-				y: Math.round(v.y),
-			}
+					const currentRounded = {
+						x: Math.round(v.x),
+						y: Math.round(v.y),
+					};
 
-			const nextRounded = {
-				x: Math.round(nextSection.x),
-				y: Math.round(nextSection.y),
-			};
+					const nextRounded = {
+						x: Math.round(nextSection.x),
+						y: Math.round(nextSection.y),
+					};
 
-			if (
-				currentRounded.x === lastRounded.x &&
-				nextRounded.x > currentRounded.x
-			) {
-				// Bend to the right
-				if (lastRounded.y > currentRounded.y) {
-					// From the bottom
-					return `L${v.x},${v.y + bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
-				}
+					if (currentRounded.x === lastRounded.x && nextRounded.x > currentRounded.x) {
+						// Bend to the right
+						if (lastRounded.y > currentRounded.y) {
+							// From the bottom
+							return `L${v.x},${v.y + bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
+						}
 
-				// From the top
-				return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
-			}
+						// From the top
+						return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
+					}
 
-			if (
-				currentRounded.x === lastRounded.x &&
-				nextRounded.x < currentRounded.x
-			) {
-				// Bend to the left
-				if (lastRounded.y > currentRounded.y) {
-					// From the bottom
-					return `L${v.x},${v.y + bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
-				}
+					if (currentRounded.x === lastRounded.x && nextRounded.x < currentRounded.x) {
+						// Bend to the left
+						if (lastRounded.y > currentRounded.y) {
+							// From the bottom
+							return `L${v.x},${v.y + bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
+						}
 
-				// From the top
-				return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
-			}
+						// From the top
+						return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
+					}
 
-			if (
-				currentRounded.y === lastRounded.y &&
-				nextRounded.y > currentRounded.y
-			) {
-				// Bend to the bottom
-				if (lastRounded.x > currentRounded.x) {
-					// From the right
-					return `L${v.x + bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
-				}
+					if (currentRounded.y === lastRounded.y && nextRounded.y > currentRounded.y) {
+						// Bend to the bottom
+						if (lastRounded.x > currentRounded.x) {
+							// From the right
+							return `L${v.x + bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
+						}
 
-				// From the left
-				return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
-			}
+						// From the left
+						return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
+					}
 
-			if (
-				currentRounded.y === lastRounded.y &&
-				nextRounded.y < currentRounded.y
-			) {
-				// Bend to the top
-				if (lastRounded.x > currentRounded.x) {
-					// From the right
-					return `L${v.x + bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y - bendRadius}`;
-				}
+					if (currentRounded.y === lastRounded.y && nextRounded.y < currentRounded.y) {
+						// Bend to the top
+						if (lastRounded.x > currentRounded.x) {
+							// From the right
+							return `L${v.x + bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y - bendRadius}`;
+						}
 
-				// From the left
-				return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y - bendRadius}`;
-			}
+						// From the left
+						return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y - bendRadius}`;
+					}
 
-			console.error("Unknown bend direction", lastRounded, currentRounded, nextRounded);
+					console.error(
+						"Unknown bend direction",
+						lastRounded,
+						currentRounded,
+						nextRounded,
+					);
 
-			return `L${v.x},${v.y}`;
-		}).join(' ') || "";
+					return `L${v.x},${v.y}`;
+				})
+				.join(" ") || "";
 
 		return `M${bendSection.startPoint.x},${bendSection.startPoint.y} ${bends} L${bendSection.endPoint.x},${bendSection.endPoint.y}`;
 	}, [bendSection, sourceX, sourceY, targetX, targetY]);
@@ -134,7 +129,10 @@ export function ElkStepEdge({
 			const firstMiddleBendLocation = Math.floor(bendSection.bendPoints.length / 2) - 1;
 			const firstMiddleBend = bendSection.bendPoints[firstMiddleBendLocation];
 			const lastMiddleBendLocation = Math.ceil(bendSection.bendPoints.length / 2) - 1;
-			const lastMiddleBend = lastMiddleBendLocation === firstMiddleBendLocation ? bendSection.bendPoints[lastMiddleBendLocation + 1] : bendSection.bendPoints[lastMiddleBendLocation];
+			const lastMiddleBend =
+				lastMiddleBendLocation === firstMiddleBendLocation
+					? bendSection.bendPoints[lastMiddleBendLocation + 1]
+					: bendSection.bendPoints[lastMiddleBendLocation];
 
 			position.x = firstMiddleBend.x + (lastMiddleBend.x - firstMiddleBend.x) / 2;
 			position.y = firstMiddleBend.y + (lastMiddleBend.y - firstMiddleBend.y) / 2;
@@ -143,7 +141,7 @@ export function ElkStepEdge({
 		return position;
 	}, [bendSection, sourceX, sourceY, targetX, targetY]);
 
-	if (!bendSection || data?.elkData?.isDragged) {
+	if (!bendSection || data?.isDragged) {
 		return (
 			<SmoothStepEdge
 				{...rest}

--- a/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -1,0 +1,132 @@
+import { useMemo } from "react";
+import { BaseEdge, EdgeProps, SmoothStepEdge } from "reactflow";
+
+interface EdgeData extends Object {
+	data: any;
+	elkData?: {
+		bendSections: import("elkjs/lib/elk.bundled").ElkEdgeSection[];
+		isDragged: boolean;
+	}
+}
+
+export function ElkStepEdge({
+	sourceX,
+	sourceY,
+	targetX,
+	targetY,
+	data,
+	...rest
+}: EdgeProps<EdgeData>) {
+	const bendSection = useMemo(() => !!data?.elkData?.bendSections ? data.elkData.bendSections[0] : undefined, [data?.elkData?.bendSections]);
+
+	const edgePath = useMemo(() => {
+		if (!bendSection) {
+			return `M${sourceX},${sourceY} L${targetX},${targetY}`;
+		}
+
+		const bendRadius = 8;
+
+		const bends: string = bendSection.bendPoints?.map((v, index, arr) => {
+			const lastSection = arr[index - 1] ?? bendSection.startPoint;
+			const nextSection = arr[index + 1] ?? bendSection.endPoint;
+
+			if (
+				v.x === lastSection.x &&
+				nextSection.x > v.x
+			) {
+				if (v.y < lastSection.y) {
+					// bends to the right from the bottom
+					return `L${v.x},${v.y + bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
+				}
+
+				// bends to the right from the top
+				return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x + bendRadius},${v.y}`;
+			} else if (
+				v.x === lastSection.x &&
+				nextSection.x < v.x
+			) {
+				if (v.y < lastSection.y) {
+					// bends to the left from the bottom
+					return `L${v.x},${v.y + bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
+				}
+
+				// bends to the left from the top
+				return `L${v.x},${v.y - bendRadius} Q${v.x},${v.y}, ${v.x - bendRadius},${v.y}`;
+			} else if (
+				v.y === lastSection.y &&
+				nextSection.y > v.y
+			) {
+				if (v.x < lastSection.x) {
+					// bends down from the right
+					return `L${v.x + bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
+				}
+
+				// bends down from the left
+				return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y + bendRadius}`;
+			} else if (
+				v.y === lastSection.y &&
+				nextSection.y < v.y
+			) {
+				if (v.x < lastSection.x) {
+					// bends up from the right
+					return `L${v.x + bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y - bendRadius}`;
+				}
+
+				// bends up from the left
+				return `L${v.x - bendRadius},${v.y} Q${v.x},${v.y}, ${v.x},${v.y - bendRadius}`;
+			}
+
+			return `L${v.x},${v.y}`;
+		}).join(' ') || "";
+
+		return `M${bendSection.startPoint.x},${bendSection.startPoint.y} ${bends} L${bendSection.endPoint.x},${bendSection.endPoint.y}`;
+	}, [bendSection]);
+
+	const labelPosition = useMemo(() => {
+		if (!bendSection) {
+			return {
+				x: sourceX + (targetX - sourceX) / 2,
+				y: sourceY + (targetY - sourceY) / 2,
+			};
+		}
+
+		const position = {
+			x: bendSection.startPoint.x + (bendSection.endPoint.x - bendSection.startPoint.x) / 2,
+			y: bendSection.startPoint.y + (bendSection.endPoint.y - bendSection.startPoint.y) / 2,
+		};
+
+		if (bendSection.bendPoints && bendSection.bendPoints.length > 0) {
+			const firstMiddleBendLocation = Math.floor(bendSection.bendPoints.length / 2) - 1;
+			const firstMiddleBend = bendSection.bendPoints[firstMiddleBendLocation];
+			const lastMiddleBendLocation = Math.ceil(bendSection.bendPoints.length / 2) - 1;
+			const lastMiddleBend = lastMiddleBendLocation === firstMiddleBendLocation ? bendSection.bendPoints[lastMiddleBendLocation + 1] : bendSection.bendPoints[lastMiddleBendLocation];
+
+			position.x = firstMiddleBend.x + (lastMiddleBend.x - firstMiddleBend.x) / 2;
+			position.y = firstMiddleBend.y + (lastMiddleBend.y - firstMiddleBend.y) / 2;
+		}
+
+		return position;
+	}, [bendSection]);
+
+	if (!bendSection || data?.elkData?.isDragged) {
+		return (
+			<SmoothStepEdge
+				{...rest}
+				data={data}
+				sourceX={sourceX}
+				sourceY={sourceY}
+				targetX={targetX}
+				targetY={targetY}
+			/>
+		);
+	}
+
+	return (
+		<BaseEdge
+			{...rest}
+			path={edgePath}
+			labelX={labelPosition.x}
+			labelY={labelPosition.y}
+		/>
+	);
+}

--- a/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -24,11 +24,17 @@ export function ElkStepEdge({
 			return `M${sourceX},${sourceY} L${targetX},${targetY}`;
 		}
 
-		const bendRadius = 8;
-
 		const bends: string = bendSection.bendPoints?.map((v, index, arr) => {
 			const lastSection = arr[index - 1] ?? bendSection.startPoint;
 			const nextSection = arr[index + 1] ?? bendSection.endPoint;
+
+			const lastLength = Math.max(Math.abs(lastSection.x - v.x), Math.abs(lastSection.y - v.y));
+			const nextLength = Math.max(Math.abs(nextSection.x - v.x), Math.abs(nextSection.y - v.y));
+
+			const _bend = Math.min(lastLength, nextLength) / 2;
+			const maxBendRadius = 36;
+
+			const bendRadius = _bend < maxBendRadius ? _bend : maxBendRadius;
 
 			if (
 				v.x === lastSection.x &&

--- a/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -1,6 +1,14 @@
 import { useMemo } from "react";
-import { BaseEdge, type EdgeProps, SmoothStepEdge } from "reactflow";
-import type { EdgeData } from "../helpers";
+import { BaseEdge, type Edge, type EdgeProps, SmoothStepEdge } from "@xyflow/react";
+import type { ElkEdgeSection } from "elkjs/lib/elk-api";
+
+export type ElkEdge = Edge<
+	{
+		isDragged: boolean;
+		path?: ElkEdgeSection;
+	},
+	"elk"
+>;
 
 export function ElkStepEdge({
 	sourceX,
@@ -9,7 +17,7 @@ export function ElkStepEdge({
 	targetY,
 	data,
 	...rest
-}: EdgeProps<EdgeData>) {
+}: EdgeProps<ElkEdge>) {
 	const bendSection = data?.path;
 
 	const edgePath = useMemo(() => {
@@ -145,7 +153,6 @@ export function ElkStepEdge({
 		return (
 			<SmoothStepEdge
 				{...rest}
-				data={data}
 				sourceX={sourceX}
 				sourceY={sourceY}
 				targetX={targetX}

--- a/src/screens/database/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/helpers.tsx
@@ -1,6 +1,14 @@
 import classes from "./style.module.scss";
 
-import type { Edge, EdgeChange, EdgeTypes, Node, NodeChange, NodeTypes } from "@xyflow/react";
+import {
+	MarkerType,
+	type Edge,
+	type EdgeChange,
+	type EdgeTypes,
+	type Node,
+	type NodeChange,
+	type NodeTypes,
+} from "@xyflow/react";
 import { toBlob, toSvg } from "html-to-image";
 import type { DiagramDirection, TableInfo } from "~/types";
 import { getSetting } from "~/util/config";
@@ -105,8 +113,6 @@ export function buildFlowNodes(
 			type: isEdge ? "edge" : "table",
 			position: { x: 0, y: 0 },
 			deletable: false,
-			// sourcePosition: Position.Right,
-			// targetPosition: Position.Left,
 			data: {
 				table,
 				isSelected: false,
@@ -141,6 +147,12 @@ export function buildFlowNodes(
 				id: `tb-${table.schema.name}-from-edge-${fromTable}`,
 				source: fromTable,
 				target: table.schema.name,
+				markerEnd: {
+					type: MarkerType.Arrow,
+					width: 14,
+					height: 14,
+					color: "#ffffff",
+				},
 			});
 
 			const node = nodeIndex[fromTable];
@@ -169,6 +181,12 @@ export function buildFlowNodes(
 				id: `tb-${table.schema.name}-to-edge-${toTable}`,
 				source: table.schema.name,
 				target: toTable,
+				markerEnd: {
+					type: MarkerType.Arrow,
+					width: 14,
+					height: 14,
+					color: "#ffffff",
+				},
 			});
 
 			const node = nodeIndex[toTable];
@@ -185,6 +203,9 @@ export function buildFlowNodes(
 	// Define all record links
 	if (showLinks) {
 		const uniqueLinks = new Set<string>();
+		const linkColor = getComputedStyle(document.body).getPropertyValue(
+			"--mantine-color-slate-5",
+		);
 
 		for (const table of tables) {
 			for (const field of table.fields) {
@@ -234,8 +255,14 @@ export function buildFlowNodes(
 						className: classes.recordLink,
 						label: field.name,
 						labelBgStyle: { fill: "var(--mantine-color-slate-8" },
-						labelStyle: { fill: "white" },
+						labelStyle: { fill: "currentColor" },
 						data: { linkCount: 1 },
+						markerEnd: {
+							type: MarkerType.Arrow,
+							width: 14,
+							height: 14,
+							color: linkColor,
+						},
 					};
 
 					uniqueLinks.add(`${table.schema.name}:${target}`);
@@ -249,8 +276,6 @@ export function buildFlowNodes(
 
 	return [nodes, edges, warnings];
 }
-
-type NodeEdge = { id: string; path?: ElkEdgeSection };
 
 /**
  * Apply a layout to the given nodes and edges

--- a/src/screens/database/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/helpers.tsx
@@ -1,3 +1,5 @@
+import classes from "./style.module.scss";
+
 import { toBlob, toSvg } from "html-to-image";
 import { type Edge, type Node, type NodeChange, Position } from "reactflow";
 import type { DiagramDirection, TableInfo } from "~/types";
@@ -7,7 +9,7 @@ import { extractKindRecords } from "~/util/surrealql";
 import { ElkStepEdge } from "./edges/ElkEdge";
 import { EdgeNode } from "./nodes/EdgeNode";
 import { TableNode } from "./nodes/TableNode";
-import classes from "./style.module.scss";
+import type { ElkEdgeSection } from "elkjs/lib/elk-api";
 
 type EdgeWarning = {
 	type: "edge";
@@ -39,6 +41,11 @@ export interface NodeData {
 	isSelected: boolean;
 	hasIncoming: boolean;
 	hasOutgoing: boolean;
+}
+
+export interface EdgeData {
+	isDragged: boolean;
+	path?: ElkEdgeSection;
 }
 
 interface NormalizedTable {
@@ -247,6 +254,7 @@ export function buildFlowNodes(
 }
 
 type DimensionNode = { id: string; width: number; height: number };
+type NodeEdge = { id: string; path?: ElkEdgeSection };
 
 /**
  * Apply a layout to the given nodes and edges
@@ -259,7 +267,7 @@ export async function applyNodeLayout(
 	nodes: DimensionNode[],
 	edges: Edge[],
 	direction: DiagramDirection,
-): Promise<[NodeChange[], { id: string, bendSections: any[] }[]]> {
+): Promise<[NodeChange[], NodeEdge[]]> {
 	if (nodes.some((node) => !node.width || !node.height)) {
 		return [[], []];
 	}
@@ -305,7 +313,7 @@ export async function applyNodeLayout(
 		}),
 		layoutEdges.map(({ id, sections }) => ({
 			id,
-			bendSections: sections || []
+			path: sections?.[0],
 		})),
 	];
 }

--- a/src/screens/database/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/helpers.tsx
@@ -4,10 +4,10 @@ import type { DiagramDirection, TableInfo } from "~/types";
 import { getSetting } from "~/util/config";
 import { extractEdgeRecords } from "~/util/schema";
 import { extractKindRecords } from "~/util/surrealql";
+import { ElkStepEdge } from "./edges/ElkEdge";
 import { EdgeNode } from "./nodes/EdgeNode";
 import { TableNode } from "./nodes/TableNode";
 import classes from "./style.module.scss";
-import { ElkStepEdge } from "./edges/ElkEdge";
 
 type EdgeWarning = {
 	type: "edge";

--- a/src/screens/database/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/helpers.tsx
@@ -1,15 +1,17 @@
 import classes from "./style.module.scss";
 
 import {
-	MarkerType,
 	type Edge,
 	type EdgeChange,
 	type EdgeTypes,
+	MarkerType,
 	type Node,
 	type NodeChange,
 	type NodeTypes,
 } from "@xyflow/react";
+import type { ElkEdgeSection } from "elkjs/lib/elk-api";
 import { toBlob, toSvg } from "html-to-image";
+import { objectify } from "radash";
 import type { DiagramDirection, TableInfo } from "~/types";
 import { getSetting } from "~/util/config";
 import { extractEdgeRecords } from "~/util/schema";
@@ -17,8 +19,6 @@ import { extractKindRecords } from "~/util/surrealql";
 import { ElkStepEdge } from "./edges/ElkEdge";
 import { EdgeNode } from "./nodes/EdgeNode";
 import { TableNode } from "./nodes/TableNode";
-import type { ElkEdgeSection } from "elkjs/lib/elk-api";
-import { objectify } from "radash";
 
 type EdgeWarning = {
 	type: "edge";

--- a/src/screens/database/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/index.tsx
@@ -73,10 +73,10 @@ import { useIsLight } from "~/hooks/theme";
 import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
 import type { DiagramDirection, DiagramMode, TableInfo } from "~/types";
+import { getSetting } from "~/util/config";
 import { showInfo } from "~/util/helpers";
 import { themeColor } from "~/util/mantine";
 import { GraphWarningLine } from "./components";
-import { getSetting } from "~/util/config";
 
 export interface TableGraphPaneProps {
 	active: string | null;

--- a/src/screens/database/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/index.tsx
@@ -134,6 +134,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 
 			if (changes.length > 0) {
 				doFitRef.current = true;
+
 				handleOnNodesChange(layoutChanges[0]);
 
 				setEdges((prev) => {
@@ -148,14 +149,13 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 							...curr,
 							data: {
 								...curr.data,
-								elkData: {
-									bendSections: found.bendSections,
-									isDragged: false,
-								}
-							}
+								path: found.path,
+								isDragged: false,
+							},
 						};
-					})
+					});
 				});
+
 				fitView();
 			}
 		}
@@ -176,7 +176,9 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 					continue;
 				}
 
-				const edgesToChange = edges.filter(({ target, source }) => target === node.id || source === node.id).map(({ id }) => id);
+				const edgesToChange = edges
+					.filter(({ target, source }) => target === node.id || source === node.id)
+					.map(({ id }) => id);
 
 				for (const edge of edgesToChange) {
 					uniqueChanges.add(edge);
@@ -188,22 +190,21 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 			return;
 		}
 
-		setEdges((prev) => prev.map((edge) => {
-			if (!uniqueChanges.has(edge.id)) {
-				return edge;
-			}
+		setEdges((prev) =>
+			prev.map((edge) => {
+				if (!uniqueChanges.has(edge.id)) {
+					return edge;
+				}
 
-			return {
-				...edge,
-				data: {
-					...edge.data,
-					elkData: edge.data.elkData ? {
-						...edge.data.elkData,
+				return {
+					...edge,
+					data: {
+						...edge.data,
 						isDragged: true,
-					} : undefined,
-				},
-			}
-		}));
+					},
+				};
+			}),
+		);
 	});
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: Fit view when nodes change

--- a/src/screens/database/views/designer/TableGraphPane/nodes/BaseNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/BaseNode.tsx
@@ -200,13 +200,15 @@ export function BaseNode({
 	const inField = table.fields.find((f) => f.name === "in");
 	const outField = table.fields.find((f) => f.name === "out");
 
+	console.log();
+
 	return (
 		<>
 			<Handle
 				type="target"
 				position={isLTR ? Position.Left : Position.Right}
 				style={{
-					visibility: hasIncoming ? "visible" : "hidden",
+					visibility: "hidden",
 				}}
 			/>
 
@@ -214,7 +216,7 @@ export function BaseNode({
 				type="source"
 				position={isLTR ? Position.Right : Position.Left}
 				style={{
-					visibility: hasOutgoing ? "visible" : "hidden",
+					visibility: "hidden",
 				}}
 			/>
 

--- a/src/screens/database/views/designer/TableGraphPane/nodes/BaseNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/BaseNode.tsx
@@ -1,14 +1,4 @@
-import {
-	Box,
-	Divider,
-	Flex,
-	Group,
-	Paper,
-	ScrollArea,
-	Stack,
-	Text,
-	Tooltip,
-} from "@mantine/core";
+import { Box, Divider, Flex, Group, Paper, ScrollArea, Stack, Text, Tooltip } from "@mantine/core";
 import { type MouseEvent, type ReactNode, useRef } from "react";
 import { Handle, Position } from "reactflow";
 import { Icon } from "~/components/Icon";
@@ -34,11 +24,17 @@ function Summary(props: SummaryProps) {
 	const valueColor = props.value > 0 ? "surreal" : "dimmed";
 
 	return (
-		<Group pr={4} wrap="nowrap">
+		<Group
+			pr={4}
+			wrap="nowrap"
+		>
 			<Icon path={props.icon} />
 			<Text c={props.isLight ? "slate.9" : "white"}>{props.title}</Text>
 			<Spacer />
-			<Text c={valueColor} fw={600}>
+			<Text
+				c={valueColor}
+				fw={600}
+			>
 				{props.value}
 			</Text>
 		</Group>
@@ -53,7 +49,12 @@ function FieldKind({ kind }: FieldKindProps) {
 	const simpleKind = simplifyKind(kind);
 
 	const value = (
-		<Text c="surreal.6" ff="mono" maw="50%" truncate>
+		<Text
+			c="surreal.6"
+			ff="mono"
+			maw="50%"
+			truncate
+		>
 			{simpleKind}
 		</Text>
 	);
@@ -67,7 +68,10 @@ function FieldKind({ kind }: FieldKindProps) {
 			position="top"
 			openDelay={0}
 			label={
-				<Text fw={500} ff="monospace">
+				<Text
+					fw={500}
+					ff="monospace"
+				>
 					{kind}
 				</Text>
 			}
@@ -85,8 +89,16 @@ interface FieldProps {
 
 function Field({ isLight, name, value }: FieldProps) {
 	return (
-		<Flex key={name} justify="space-between" gap="xl">
-			<Text title={name} c={isLight ? undefined : "white"} truncate>
+		<Flex
+			key={name}
+			justify="space-between"
+			gap="xl"
+		>
+			<Text
+				title={name}
+				c={isLight ? undefined : "white"}
+				truncate
+			>
 				{name}
 			</Text>
 			{value}
@@ -117,7 +129,10 @@ function Fields(props: FieldsProps) {
 	});
 
 	return (
-		<Box display="flex" style={{ cursor: "pointer" }}>
+		<Box
+			display="flex"
+			style={{ cursor: "pointer" }}
+		>
 			<ScrollArea
 				flex={1}
 				mah={210}
@@ -128,7 +143,11 @@ function Fields(props: FieldsProps) {
 				className={classes.fieldsScroll}
 				onScrollPositionChange={skipMouse}
 			>
-				<Stack gap="xs" mt={10} p={0}>
+				<Stack
+					gap="xs"
+					mt={10}
+					p={0}
+				>
 					{fields.map((field) => (
 						<Field
 							key={field.name}
@@ -138,7 +157,10 @@ function Fields(props: FieldsProps) {
 								field.kind ? (
 									<FieldKind kind={field.kind} />
 								) : (
-									<Text c="slate" title={field.kind}>
+									<Text
+										c="slate"
+										title={field.kind}
+									>
 										none
 									</Text>
 								)
@@ -152,6 +174,7 @@ function Fields(props: FieldsProps) {
 }
 
 interface BaseNodeProps {
+	id: string;
 	icon: string;
 	table: TableInfo;
 	isSelected: boolean;
@@ -161,6 +184,7 @@ interface BaseNodeProps {
 }
 
 export function BaseNode({
+	id,
 	icon,
 	table,
 	isSelected,
@@ -173,8 +197,7 @@ export function BaseNode({
 	const isLight = useIsLight();
 	const isLTR = diagramDirection === "ltr";
 	const showMore =
-		diagramMode === "summary" ||
-		(diagramMode === "fields" && table.fields.length > 0);
+		diagramMode === "summary" || (diagramMode === "fields" && table.fields.length > 0);
 
 	const inField = table.fields.find((f) => f.name === "in");
 	const outField = table.fields.find((f) => f.name === "out");
@@ -215,13 +238,7 @@ export function BaseNode({
 				>
 					<Icon
 						path={icon}
-						color={
-							isSelected
-								? "surreal"
-								: isLight
-									? "slate.7"
-									: "slate.2"
-						}
+						color={isSelected ? "surreal" : isLight ? "slate.7" : "slate.2"}
 					/>
 					<Text
 						style={{
@@ -239,15 +256,17 @@ export function BaseNode({
 							color={isLight ? "slate.2" : "slate.6"}
 							my="sm"
 						/>
-						<Stack gap="xs" mt={10} p={0}>
+						<Stack
+							gap="xs"
+							mt={10}
+							p={0}
+						>
 							<Field
 								isLight={isLight}
 								name="in"
 								value={
 									<Text ta="right">
-										{extractKindRecords(
-											inField.kind ?? "",
-										).join(", ")}
+										{extractKindRecords(inField.kind ?? "").join(", ")}
 									</Text>
 								}
 							/>
@@ -256,9 +275,7 @@ export function BaseNode({
 								name="out"
 								value={
 									<Text ta="right">
-										{extractKindRecords(
-											outField.kind ?? "",
-										).join(", ")}
+										{extractKindRecords(outField.kind ?? "").join(", ")}
 									</Text>
 								}
 							/>
@@ -274,9 +291,16 @@ export function BaseNode({
 						/>
 
 						{diagramMode === "fields" ? (
-							<Fields isLight={isLight} table={table} />
+							<Fields
+								isLight={isLight}
+								table={table}
+							/>
 						) : (
-							<Stack gap="xs" mt={10} p={0}>
+							<Stack
+								gap="xs"
+								mt={10}
+								p={0}
+							>
 								<Summary
 									isLight={isLight}
 									icon={iconJSON}

--- a/src/screens/database/views/designer/TableGraphPane/nodes/BaseNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/BaseNode.tsx
@@ -1,6 +1,6 @@
 import { Box, Divider, Flex, Group, Paper, ScrollArea, Stack, Text, Tooltip } from "@mantine/core";
-import { type MouseEvent, type ReactNode, useRef } from "react";
 import { Handle, Position, useInternalNode } from "@xyflow/react";
+import { type MouseEvent, type ReactNode, useRef } from "react";
 import { Icon } from "~/components/Icon";
 import { Spacer } from "~/components/Spacer";
 import { useActiveConnection } from "~/hooks/connection";

--- a/src/screens/database/views/designer/TableGraphPane/nodes/BaseNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/BaseNode.tsx
@@ -1,6 +1,6 @@
 import { Box, Divider, Flex, Group, Paper, ScrollArea, Stack, Text, Tooltip } from "@mantine/core";
 import { type MouseEvent, type ReactNode, useRef } from "react";
-import { Handle, Position } from "reactflow";
+import { Handle, Position, useInternalNode } from "@xyflow/react";
 import { Icon } from "~/components/Icon";
 import { Spacer } from "~/components/Spacer";
 import { useActiveConnection } from "~/hooks/connection";
@@ -174,7 +174,6 @@ function Fields(props: FieldsProps) {
 }
 
 interface BaseNodeProps {
-	id: string;
 	icon: string;
 	table: TableInfo;
 	isSelected: boolean;
@@ -184,7 +183,6 @@ interface BaseNodeProps {
 }
 
 export function BaseNode({
-	id,
 	icon,
 	table,
 	isSelected,

--- a/src/screens/database/views/designer/TableGraphPane/nodes/EdgeNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/EdgeNode.tsx
@@ -1,14 +1,12 @@
 import { iconRelation } from "~/util/icons";
 import type { NodeData } from "../helpers";
 import { BaseNode } from "./BaseNode";
+import type { NodeProps } from "reactflow";
 
-interface EdgeNodeProps {
-	data: NodeData;
-}
-
-export function EdgeNode({ data }: EdgeNodeProps) {
+export function EdgeNode({ id, data }: NodeProps<NodeData>) {
 	return (
 		<BaseNode
+			id={id}
 			icon={iconRelation}
 			table={data.table}
 			isSelected={data.isSelected}

--- a/src/screens/database/views/designer/TableGraphPane/nodes/EdgeNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/EdgeNode.tsx
@@ -1,12 +1,13 @@
 import { iconRelation } from "~/util/icons";
-import type { NodeData } from "../helpers";
 import { BaseNode } from "./BaseNode";
-import type { NodeProps } from "reactflow";
+import type { Node, NodeProps } from "@xyflow/react";
+import type { SharedNodeData } from "../helpers";
 
-export function EdgeNode({ id, data }: NodeProps<NodeData>) {
+export type EdgeNode = Node<SharedNodeData, "edge">;
+
+export function EdgeNode({ data }: NodeProps<EdgeNode>) {
 	return (
 		<BaseNode
-			id={id}
 			icon={iconRelation}
 			table={data.table}
 			isSelected={data.isSelected}

--- a/src/screens/database/views/designer/TableGraphPane/nodes/EdgeNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/EdgeNode.tsx
@@ -1,7 +1,7 @@
-import { iconRelation } from "~/util/icons";
-import { BaseNode } from "./BaseNode";
 import type { Node, NodeProps } from "@xyflow/react";
+import { iconRelation } from "~/util/icons";
 import type { SharedNodeData } from "../helpers";
+import { BaseNode } from "./BaseNode";
 
 export type EdgeNode = Node<SharedNodeData, "edge">;
 

--- a/src/screens/database/views/designer/TableGraphPane/nodes/TableNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/TableNode.tsx
@@ -1,12 +1,13 @@
 import { iconTable } from "~/util/icons";
-import type { NodeData } from "../helpers";
 import { BaseNode } from "./BaseNode";
-import type { NodeProps } from "reactflow";
+import type { Node, NodeProps } from "@xyflow/react";
+import type { SharedNodeData } from "../helpers";
 
-export function TableNode({ id, data }: NodeProps<NodeData>) {
+export type TableNode = Node<SharedNodeData, "table">;
+
+export function TableNode({ data }: NodeProps<TableNode>) {
 	return (
 		<BaseNode
-			id={id}
 			icon={iconTable}
 			table={data.table}
 			isSelected={data.isSelected}

--- a/src/screens/database/views/designer/TableGraphPane/nodes/TableNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/TableNode.tsx
@@ -1,7 +1,7 @@
-import { iconTable } from "~/util/icons";
-import { BaseNode } from "./BaseNode";
 import type { Node, NodeProps } from "@xyflow/react";
+import { iconTable } from "~/util/icons";
 import type { SharedNodeData } from "../helpers";
+import { BaseNode } from "./BaseNode";
 
 export type TableNode = Node<SharedNodeData, "table">;
 

--- a/src/screens/database/views/designer/TableGraphPane/nodes/TableNode.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/nodes/TableNode.tsx
@@ -1,14 +1,12 @@
 import { iconTable } from "~/util/icons";
 import type { NodeData } from "../helpers";
 import { BaseNode } from "./BaseNode";
+import type { NodeProps } from "reactflow";
 
-interface TableNodeProps {
-	data: NodeData;
-}
-
-export function TableNode({ data }: TableNodeProps) {
+export function TableNode({ id, data }: NodeProps<NodeData>) {
 	return (
 		<BaseNode
+			id={id}
 			icon={iconTable}
 			table={data.table}
 			isSelected={data.isSelected}

--- a/src/screens/database/views/designer/TableGraphPane/style.module.scss
+++ b/src/screens/database/views/designer/TableGraphPane/style.module.scss
@@ -3,18 +3,18 @@
 	inset: 12px;
 	top: 0;
 
-	> div > div {
+	>div>div {
 		height: 100%;
 	}
 }
 
-.fields-scroll > div > div {
+.fields-scroll>div>div {
 	display: block !important;
 }
 
 .list {
 	padding-left: 24px;
-	
+
 	li::marker {
 		color: var(--mantine-color-surreal-5);
 	}
@@ -22,37 +22,37 @@
 
 .diagram {
 
-	:global(.react-flow__handle) {
-		// backdrop-filter: blur(2px);
-		// -webkit-backdrop-filter: blur(2px);
-		background-color: rgba(0, 0, 0, 0.4) !important;
-		border: 1px solid var(--mantine-color-slate-5) !important;
-		box-shadow: 0 2px 5px rgba(0, 0, 0, 0.35);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		cursor: unset;
+	// :global(.react-flow__handle) {
+	// 	// backdrop-filter: blur(2px);
+	// 	// -webkit-backdrop-filter: blur(2px);
+	// 	background-color: rgba(0, 0, 0, 0.4) !important;
+	// 	border: 1px solid var(--mantine-color-slate-5) !important;
+	// 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.35);
+	// 	display: flex;
+	// 	align-items: center;
+	// 	justify-content: center;
+	// 	cursor: unset;
 
-		&::before {
-			content: "";
-			width: 9px;
-			height: 9px;
-			border-radius: 100%;
-			background-color: white;
-		}
-	}
+	// 	&::before {
+	// 		content: "";
+	// 		width: 9px;
+	// 		height: 9px;
+	// 		border-radius: 100%;
+	// 		background-color: white;
+	// 	}
+	// }
 
-	:global(.react-flow__handle-left) {
-		width: 18px;
-		height: 18px;
-		left: -9px;
-	}
+	// :global(.react-flow__handle-left) {
+	// 	width: 18px;
+	// 	height: 18px;
+	// 	left: -9px;
+	// }
 
-	:global(.react-flow__handle-right) {
-		width: 18px;
-		height: 18px;
-		right: -9px;
-	}
+	// :global(.react-flow__handle-right) {
+	// 	width: 18px;
+	// 	height: 18px;
+	// 	right: -9px;
+	// }
 
 	:global(.react-flow__edge > path) {
 		stroke-width: 2px;

--- a/src/startup/surrealist.tsx
+++ b/src/startup/surrealist.tsx
@@ -1,4 +1,4 @@
-import "reactflow/dist/style.css";
+import "@xyflow/react/dist/style.css";
 import "@mantine/core/styles.layer.css";
 import "@mantine/notifications/styles.css";
 import "mantine-contextmenu/styles.layer.css";


### PR DESCRIPTION
Update to the designer view to have the edges between the nodes be routed by the values generated from elkjs instead of the native paths generated by reactflow.

On drag the elkjs generated paths turn into the native paths from reactflow as the path that i have is no longer a valid path.

e.g. before:
![image](https://github.com/user-attachments/assets/0fcfc1a6-24f8-4946-a32f-d450a340d2a2)


e.g. after:
![image](https://github.com/user-attachments/assets/5261d73a-d816-49f3-b4ea-23bb0523b270)
