### PR TITLE
Add table and query panel collapsing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,6 +30,15 @@
 			"icon": {
 				"id": "vm-running"
 			}
+		},
+		{
+			"type": "npm",
+			"script": "lint:apply:unsafe",
+			"label": "Lint unsafe (Apply fixes)",
+			"detail": "Run the linter and fix issues",
+			"icon": {
+				"id": "vm-running"
+			}
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"react-dom": "^18.2.0",
 		"react-error-boundary": "^4.0.12",
 		"react-leaflet": "^4.2.1",
-		"react-resizable-panels": "^2.0.5",
+		"react-resizable-panels": "^2.1.4",
 		"react-reverse-portal": "^2.1.1",
 		"rss-parser": "^3.13.0",
 		"surrealdb": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1(leaflet@1.9.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-resizable-panels:
-        specifier: ^2.0.5
-        version: 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^2.1.4
+        version: 2.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-reverse-portal:
         specifier: ^2.1.1
         version: 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2477,8 +2477,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-resizable-panels@2.1.1:
-    resolution: {integrity: sha512-+cUV/yZBYfiBj+WJtpWDJ3NtR4zgDZfHt3+xtaETKE+FCvp+RK/NJxacDQKxMHgRUTSkfA6AnGljQ5QZNsCQoA==}
+  react-resizable-panels@2.1.4:
+    resolution: {integrity: sha512-kzue8lsoSBdyyd2IfXLQMMhNujOxRoGVus+63K95fQqleGxTfvgYLTzbwYMOODeAHqnkjb3WV/Ks7f5+gDYZuQ==}
     peerDependencies:
       react: ^16.14.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
@@ -5193,7 +5193,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.4
 
-  react-resizable-panels@2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-resizable-panels@2.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/src/components/ActionButton/index.tsx
+++ b/src/components/ActionButton/index.tsx
@@ -1,0 +1,36 @@
+import {
+	ActionIcon,
+	type ActionIconProps,
+	type ElementProps,
+	Tooltip,
+	type TooltipProps,
+} from "@mantine/core";
+import type { PropsWithChildren } from "react";
+
+export interface ActionButtonProps extends ActionIconProps, ElementProps<"button", "color"> {
+	label: string;
+	tooltipProps?: TooltipProps;
+}
+
+/**
+ * Combination of a Tooltip and an ActionIcon to create accessible icon buttons
+ */
+export function ActionButton({
+	label,
+	tooltipProps,
+	...other
+}: PropsWithChildren<ActionButtonProps>) {
+	return (
+		<Tooltip
+			label={label}
+			{...tooltipProps}
+		>
+			<ActionIcon
+				{...other}
+				aria-label={label}
+			>
+				{other.children}
+			</ActionIcon>
+		</Tooltip>
+	);
+}

--- a/src/screens/database/components/TablesPane/index.tsx
+++ b/src/screens/database/components/TablesPane/index.tsx
@@ -12,6 +12,7 @@ import { useInputState } from "@mantine/hooks";
 import { type ContextMenuItemOptions, useContextMenu } from "mantine-contextmenu";
 import { sort } from "radash";
 import { useMemo } from "react";
+import { ActionButton } from "~/components/ActionButton";
 import { Entry } from "~/components/Entry";
 import { Icon } from "~/components/Icon";
 import { ContentPane } from "~/components/Pane";
@@ -37,7 +38,6 @@ import {
 } from "~/util/icons";
 import { extractEdgeRecords, syncConnectionSchema } from "~/util/schema";
 import classes from "./style.module.scss";
-import { ActionButton } from "~/components/ActionButton";
 
 export interface TablesPaneProps {
 	icon?: string;

--- a/src/screens/database/views/designer/DesignerView/index.tsx
+++ b/src/screens/database/views/designer/DesignerView/index.tsx
@@ -15,10 +15,12 @@ import { TablesPane } from "~/screens/database/components/TablesPane";
 import { iconDesigner } from "~/util/icons";
 import { syncConnectionSchema } from "~/util/schema";
 import { TableGraphPane } from "../TableGraphPane";
+import { useConfigStore } from "~/stores/config";
 
 const TableGraphPaneLazy = memo(TableGraphPane);
 
 export function DesignerView() {
+	const { updateCurrentConnection } = useConfigStore.getState();
 	const { design, stopDesign, active, isDesigning } = useDesigner();
 	const { designerTableList } = useActiveConnection();
 
@@ -33,6 +35,12 @@ export function DesignerView() {
 			onClick: () => design(table),
 		},
 	]);
+
+	const closeTableList = useStable(() => {
+		updateCurrentConnection({
+			designerTableList: false,
+		});
+	});
 
 	useEffect(() => {
 		if (!isOnline) {
@@ -73,6 +81,7 @@ export function DesignerView() {
 									icon={iconDesigner}
 									onTableSelect={design}
 									onTableContextMenu={buildContextMenu}
+									onClose={closeTableList}
 								/>
 							</Panel>
 							<PanelDragger />
@@ -80,6 +89,7 @@ export function DesignerView() {
 					)}
 					<Panel
 						minSize={minSize}
+						id="graph"
 						order={2}
 					>
 						<ReactFlowProvider>

--- a/src/screens/database/views/designer/DesignerView/index.tsx
+++ b/src/screens/database/views/designer/DesignerView/index.tsx
@@ -12,10 +12,10 @@ import { useIntent } from "~/hooks/url";
 import { useViewEffect } from "~/hooks/view";
 import { useDesigner } from "~/providers/Designer";
 import { TablesPane } from "~/screens/database/components/TablesPane";
+import { useConfigStore } from "~/stores/config";
 import { iconDesigner } from "~/util/icons";
 import { syncConnectionSchema } from "~/util/schema";
 import { TableGraphPane } from "../TableGraphPane";
-import { useConfigStore } from "~/stores/config";
 
 const TableGraphPaneLazy = memo(TableGraphPane);
 

--- a/src/screens/database/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/index.tsx
@@ -79,6 +79,7 @@ import type { DiagramDirection, DiagramMode, TableInfo } from "~/types";
 import { showInfo } from "~/util/helpers";
 import { themeColor } from "~/util/mantine";
 import { GraphWarningLine } from "./components";
+import { ActionButton } from "~/components/ActionButton";
 
 export interface TableGraphPaneProps {
 	active: string | null;
@@ -207,9 +208,9 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 		}
 	});
 
-	const toggleTableList = useStable(() => {
+	const openTableList = useStable(() => {
 		updateCurrentConnection({
-			designerTableList: !connection.designerTableList,
+			designerTableList: true,
 		});
 	});
 
@@ -274,19 +275,17 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 			icon={iconRelation}
 			style={{ overflow: "hidden" }}
 			leftSection={
-				<Tooltip label="Toggle table list">
-					<ActionIcon
+				!connection.designerTableList && (
+					<ActionButton
+						label="Reveal tables"
 						mr="sm"
 						color="slate"
 						variant="light"
-						onClick={toggleTableList}
-						aria-label="Toggle table list"
+						onClick={openTableList}
 					>
-						<Icon
-							path={connection.designerTableList ? iconChevronLeft : iconChevronRight}
-						/>
-					</ActionIcon>
-				</Tooltip>
+						<Icon path={iconChevronRight} />
+					</ActionButton>
+				)
 			}
 			rightSection={
 				<Group wrap="nowrap">

--- a/src/screens/database/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/index.tsx
@@ -63,6 +63,7 @@ import {
 import { useContextMenu } from "mantine-contextmenu";
 import { sleep } from "radash";
 import { adapter } from "~/adapter";
+import { ActionButton } from "~/components/ActionButton";
 import { Icon } from "~/components/Icon";
 import { Link } from "~/components/Link";
 import { ContentPane } from "~/components/Pane";
@@ -79,7 +80,6 @@ import type { DiagramDirection, DiagramMode, TableInfo } from "~/types";
 import { showInfo } from "~/util/helpers";
 import { themeColor } from "~/util/mantine";
 import { GraphWarningLine } from "./components";
-import { ActionButton } from "~/components/ActionButton";
 
 export interface TableGraphPaneProps {
 	active: string | null;

--- a/src/screens/database/views/explorer/ExplorerPane/index.tsx
+++ b/src/screens/database/views/explorer/ExplorerPane/index.tsx
@@ -38,10 +38,12 @@ import {
 import { useDebouncedValue, useInputState } from "@mantine/hooks";
 import { useContextMenu } from "mantine-contextmenu";
 import { RecordId } from "surrealdb";
+import { ActionButton } from "~/components/ActionButton";
 import { DataTable } from "~/components/DataTable";
 import { Icon } from "~/components/Icon";
 import { LoadingContainer } from "~/components/LoadingContainer";
 import { ContentPane } from "~/components/Pane";
+import { useActiveConnection } from "~/hooks/connection";
 import { useEventSubscription } from "~/hooks/event";
 import { useStable } from "~/hooks/stable";
 import { executeQuery } from "~/screens/database/connection/connection";
@@ -50,8 +52,6 @@ import { RecordsChangedEvent } from "~/util/global-events";
 import { themeColor } from "~/util/mantine";
 import { formatValue, validateWhere } from "~/util/surrealql";
 import { type SortMode, usePaginationQuery, useRecordQuery } from "./hooks";
-import { useActiveConnection } from "~/hooks/connection";
-import { ActionButton } from "~/components/ActionButton";
 
 const PAGE_SIZES: ComboboxData = [
 	{ label: "10 Results per page", value: "10" },

--- a/src/screens/database/views/explorer/ExplorerPane/index.tsx
+++ b/src/screens/database/views/explorer/ExplorerPane/index.tsx
@@ -50,6 +50,8 @@ import { RecordsChangedEvent } from "~/util/global-events";
 import { themeColor } from "~/util/mantine";
 import { formatValue, validateWhere } from "~/util/surrealql";
 import { type SortMode, usePaginationQuery, useRecordQuery } from "./hooks";
+import { useActiveConnection } from "~/hooks/connection";
+import { ActionButton } from "~/components/ActionButton";
 
 const PAGE_SIZES: ComboboxData = [
 	{ label: "10 Results per page", value: "10" },
@@ -63,12 +65,10 @@ export interface ExplorerPaneProps {
 	onCreateRecord: () => void;
 }
 
-export function ExplorerPane({
-	activeTable,
-	onCreateRecord,
-}: ExplorerPaneProps) {
-	const { addQueryTab, setActiveView } = useConfigStore.getState();
+export function ExplorerPane({ activeTable, onCreateRecord }: ExplorerPaneProps) {
+	const { addQueryTab, setActiveView, updateCurrentConnection } = useConfigStore.getState();
 	const { showContextMenu } = useContextMenu();
+	const connection = useActiveConnection();
 
 	const [filtering, setFiltering] = useState(false);
 	const [filter, setFilter] = useInputState("");
@@ -145,6 +145,12 @@ export function ExplorerPane({
 		onCreateRecord();
 	});
 
+	const openTableList = useStable(() => {
+		updateCurrentConnection({
+			explorerTableList: true,
+		});
+	});
+
 	const refetch = useStable(() => {
 		recordQuery.refetch();
 		paginationQuery.refetch();
@@ -174,9 +180,7 @@ export function ExplorerPane({
 				title: "Copy as JSON",
 				icon: <Icon path={iconJSON} />,
 				onClick: () => {
-					navigator.clipboard.writeText(
-						formatValue(record, true, true),
-					);
+					navigator.clipboard.writeText(formatValue(record, true, true));
 				},
 			},
 			{
@@ -232,6 +236,20 @@ export function ExplorerPane({
 		<ContentPane
 			title="Record Explorer"
 			icon={iconTable}
+			leftSection={
+				!connection.explorerTableList && (
+					<ActionButton
+						label="Reveal tables"
+						mr="sm"
+						color="slate"
+						variant="light"
+						onClick={openTableList}
+						aria-label="Reveal tables"
+					>
+						<Icon path={iconChevronRight} />
+					</ActionButton>
+				)
+			}
 			rightSection={
 				activeTable && (
 					<Group align="center">
@@ -253,16 +271,10 @@ export function ExplorerPane({
 							</ActionIcon>
 						</Tooltip>
 
-						<Tooltip
-							label={filtering ? "Hide filter" : "Filter records"}
-						>
+						<Tooltip label={filtering ? "Hide filter" : "Filter records"}>
 							<ActionIcon
 								onClick={toggleFilter}
-								aria-label={
-									filtering
-										? "Hide filter"
-										: "Show record filter"
-								}
+								aria-label={filtering ? "Hide filter" : "Show record filter"}
 							>
 								<Icon path={iconFilter} />
 							</ActionIcon>
@@ -270,11 +282,12 @@ export function ExplorerPane({
 
 						<Divider orientation="vertical" />
 
-						<Icon path={iconServer} mr={-6} />
+						<Icon
+							path={iconServer}
+							mr={-6}
+						/>
 						<Text lineClamp={1}>
-							{recordQuery.isLoading
-								? "loading..."
-								: `${recordCount || "no"} rows`}
+							{recordQuery.isLoading ? "loading..." : `${recordCount || "no"} rows`}
 						</Text>
 					</Group>
 				)

--- a/src/screens/database/views/explorer/ExplorerView/index.tsx
+++ b/src/screens/database/views/explorer/ExplorerView/index.tsx
@@ -26,12 +26,12 @@ import { dispatchIntent, useIntent } from "~/hooks/url";
 import { useViewEffect } from "~/hooks/view";
 import { useDesigner } from "~/providers/Designer";
 import { TablesPane } from "~/screens/database/components/TablesPane";
+import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
 import { DisconnectedEvent } from "~/util/global-events";
 import { syncConnectionSchema } from "~/util/schema";
 import { CreatorDrawer } from "../CreatorDrawer";
 import { ExplorerPane } from "../ExplorerPane";
-import { useConfigStore } from "~/stores/config";
 
 const TablesPaneLazy = memo(TablesPane);
 const ExplorerPaneLazy = memo(ExplorerPane);

--- a/src/screens/database/views/explorer/ExplorerView/index.tsx
+++ b/src/screens/database/views/explorer/ExplorerView/index.tsx
@@ -18,7 +18,7 @@ import { Entry } from "~/components/Entry";
 import { Icon } from "~/components/Icon";
 import { Introduction } from "~/components/Introduction";
 import { PanelDragger } from "~/components/Pane/dragger";
-import { useConnection, useIsConnected } from "~/hooks/connection";
+import { useActiveConnection, useConnection, useIsConnected } from "~/hooks/connection";
 import { useEventSubscription } from "~/hooks/event";
 import { usePanelMinSize } from "~/hooks/panels";
 import { useStable } from "~/hooks/stable";
@@ -31,19 +31,22 @@ import { DisconnectedEvent } from "~/util/global-events";
 import { syncConnectionSchema } from "~/util/schema";
 import { CreatorDrawer } from "../CreatorDrawer";
 import { ExplorerPane } from "../ExplorerPane";
+import { useConfigStore } from "~/stores/config";
 
 const TablesPaneLazy = memo(TablesPane);
 const ExplorerPaneLazy = memo(ExplorerPane);
 
 export function ExplorerView() {
-	const connection = useConnection();
+	const { updateCurrentConnection } = useConfigStore.getState();
 	const { openTableCreator } = useInterfaceStore.getState();
+	const { explorerTableList } = useActiveConnection();
 	const { design } = useDesigner();
 
 	const [activeTable, setActiveTable] = useState<string>();
 	const [isCreating, isCreatingHandle] = useDisclosure();
 	const [creatorTable, setCreatorTable] = useState<string>();
 
+	const connection = useConnection();
 	const isConnected = useIsConnected();
 
 	const openCreator = useStable((table?: string) => {
@@ -71,6 +74,12 @@ export function ExplorerView() {
 			onClick: () => openCreator(table),
 		},
 	]);
+
+	const closeTableList = useStable(() => {
+		updateCurrentConnection({
+			explorerTableList: false,
+		});
+	});
 
 	useEventSubscription(DisconnectedEvent, () => {
 		isCreatingHandle.close();
@@ -101,43 +110,55 @@ export function ExplorerView() {
 					direction="horizontal"
 					style={{ opacity: minSize === 0 ? 0 : 1 }}
 				>
+					{(explorerTableList || !activeTable) && (
+						<>
+							<Panel
+								defaultSize={minSize}
+								minSize={minSize}
+								maxSize={35}
+								id="tables"
+								order={1}
+							>
+								<TablesPaneLazy
+									icon={iconExplorer}
+									activeTable={activeTable}
+									closeDisabled={!activeTable}
+									onTableSelect={setActiveTable}
+									onTableContextMenu={buildContextMenu}
+									onClose={closeTableList}
+									extraSection={
+										<>
+											<Entry
+												leftSection={<Icon path={iconUpload} />}
+												rightSection={<Icon path={iconChevronRight} />}
+												onClick={() => dispatchIntent("export-database")}
+												style={{ flexShrink: 0 }}
+												disabled={isExportDisabled}
+												bg="transparent"
+											>
+												Export database
+											</Entry>
+											<Entry
+												leftSection={<Icon path={iconDownload} />}
+												rightSection={<Icon path={iconChevronRight} />}
+												onClick={() => dispatchIntent("import-database")}
+												style={{ flexShrink: 0 }}
+												bg="transparent"
+											>
+												Import database
+											</Entry>
+										</>
+									}
+								/>
+							</Panel>
+							<PanelDragger />
+						</>
+					)}
 					<Panel
-						defaultSize={minSize}
+						id="explorer"
+						order={2}
 						minSize={minSize}
-						maxSize={35}
 					>
-						<TablesPaneLazy
-							icon={iconExplorer}
-							activeTable={activeTable}
-							onTableSelect={setActiveTable}
-							onTableContextMenu={buildContextMenu}
-							extraSection={
-								<>
-									<Entry
-										leftSection={<Icon path={iconUpload} />}
-										rightSection={<Icon path={iconChevronRight} />}
-										onClick={() => dispatchIntent("export-database")}
-										style={{ flexShrink: 0 }}
-										disabled={isExportDisabled}
-										bg="transparent"
-									>
-										Export database
-									</Entry>
-									<Entry
-										leftSection={<Icon path={iconDownload} />}
-										rightSection={<Icon path={iconChevronRight} />}
-										onClick={() => dispatchIntent("import-database")}
-										style={{ flexShrink: 0 }}
-										bg="transparent"
-									>
-										Import database
-									</Entry>
-								</>
-							}
-						/>
-					</Panel>
-					<PanelDragger />
-					<Panel minSize={minSize}>
 						{activeTable ? (
 							<ExplorerPaneLazy
 								activeTable={activeTable}

--- a/src/screens/database/views/query/QueryPane/index.tsx
+++ b/src/screens/database/views/query/QueryPane/index.tsx
@@ -14,10 +14,12 @@ import { ActionIcon, Group, HoverCard, Stack, ThemeIcon, Tooltip } from "@mantin
 import { Text } from "@mantine/core";
 import { surrealql } from "@surrealdb/codemirror";
 import { type HtmlPortalNode, OutPortal } from "react-reverse-portal";
+import { ActionButton } from "~/components/ActionButton";
 import { CodeEditor } from "~/components/CodeEditor";
 import { Icon } from "~/components/Icon";
 import { ContentPane } from "~/components/Pane";
 import { MAX_HISTORY_QUERY_LENGTH } from "~/constants";
+import { useActiveConnection } from "~/hooks/connection";
 import { useDebouncedFunction } from "~/hooks/debounce";
 import { useStable } from "~/hooks/stable";
 import { useIntent } from "~/hooks/url";
@@ -36,8 +38,6 @@ import {
 	iconWarning,
 } from "~/util/icons";
 import { formatQuery, formatValue, validateQuery } from "~/util/surrealql";
-import { useActiveConnection } from "~/hooks/connection";
-import { ActionButton } from "~/components/ActionButton";
 
 export interface QueryPaneProps {
 	activeTab: TabQuery;

--- a/src/screens/database/views/query/QueryPane/index.tsx
+++ b/src/screens/database/views/query/QueryPane/index.tsx
@@ -25,8 +25,19 @@ import { useInspector } from "~/providers/Inspector";
 import { useConfigStore } from "~/stores/config";
 import type { TabQuery } from "~/types";
 import { extractVariables, showError, tryParseParams } from "~/util/helpers";
-import { iconAutoFix, iconDollar, iconServer, iconStar, iconText, iconWarning } from "~/util/icons";
+import {
+	iconAutoFix,
+	iconChevronLeft,
+	iconChevronRight,
+	iconDollar,
+	iconServer,
+	iconStar,
+	iconText,
+	iconWarning,
+} from "~/util/icons";
 import { formatQuery, formatValue, validateQuery } from "~/util/surrealql";
+import { useActiveConnection } from "~/hooks/connection";
+import { ActionButton } from "~/components/ActionButton";
 
 export interface QueryPaneProps {
 	activeTab: TabQuery;
@@ -55,8 +66,10 @@ export function QueryPane({
 	onSelectionChange,
 	onEditorMounted,
 }: QueryPaneProps) {
-	const { updateQueryTab } = useConfigStore.getState();
+	const { updateQueryTab, updateCurrentConnection } = useConfigStore.getState();
 	const { inspect } = useInspector();
+
+	const connection = useActiveConnection();
 
 	const setQueryForced = useStable((query: string) => {
 		setIsValid(!validateQuery(query));
@@ -67,6 +80,12 @@ export function QueryPane({
 	});
 
 	const scheduleSetQuery = useDebouncedFunction(setQueryForced, 50);
+
+	const openQueryList = useStable(() => {
+		updateCurrentConnection({
+			queryTabList: true,
+		});
+	});
 
 	const handleFormat = useStable(() => {
 		try {
@@ -132,9 +151,22 @@ export function QueryPane({
 
 	return (
 		<ContentPane
-			title="Query"
+			title={activeTab.name ?? "Query"}
 			icon={iconServer}
 			radius={corners}
+			leftSection={
+				!connection.queryTabList && (
+					<ActionButton
+						label="Reveal queries"
+						mr="sm"
+						color="slate"
+						variant="light"
+						onClick={openQueryList}
+					>
+						<Icon path={iconChevronRight} />
+					</ActionButton>
+				)
+			}
 			rightSection={
 				switchPortal ? (
 					<OutPortal node={switchPortal} />

--- a/src/screens/database/views/query/QueryView/index.tsx
+++ b/src/screens/database/views/query/QueryView/index.tsx
@@ -33,7 +33,7 @@ import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { Spacer } from "~/components/Spacer";
 import { useLogoUrl } from "~/hooks/brand";
 import { useLineNumberSetting, useSetting } from "~/hooks/config";
-import { useActiveQuery, useSavedQueryTags } from "~/hooks/connection";
+import { useActiveConnection, useActiveQuery, useSavedQueryTags } from "~/hooks/connection";
 import { usePanelMinSize } from "~/hooks/panels";
 import { useStable } from "~/hooks/stable";
 import { useIntent } from "~/hooks/url";
@@ -57,6 +57,7 @@ const ResultPaneLazy = memo(ResultPane);
 
 export function QueryView() {
 	const { saveQuery, updateQueryTab } = useConfigStore.getState();
+	const { queryTabList } = useActiveConnection();
 	const logoUrl = useLogoUrl();
 
 	const [orientation] = useSetting("appearance", "queryOrientation");
@@ -279,18 +280,29 @@ export function QueryView() {
 					style={{ opacity: minSize === 0 ? 0 : 1 }}
 				>
 					<PanelGroup direction="horizontal">
+						{queryTabList && (
+							<>
+								<Panel
+									defaultSize={minSize}
+									minSize={minSize}
+									maxSize={35}
+									id="tabs"
+									order={1}
+								>
+									<TabsPane
+										openHistory={showHistoryHandle.open}
+										openSaved={showSavedHandle.open}
+									/>
+								</Panel>
+								<PanelDragger />
+							</>
+						)}
 						<Panel
-							defaultSize={minSize}
-							minSize={minSize}
-							maxSize={35}
+							id="content"
+							order={2}
 						>
-							<TabsPane
-								openHistory={showHistoryHandle.open}
-								openSaved={showSavedHandle.open}
-							/>
+							{queryEditor}
 						</Panel>
-						<PanelDragger />
-						<Panel>{queryEditor}</Panel>
 					</PanelGroup>
 				</Box>
 			)}

--- a/src/screens/database/views/query/TabsPane/index.tsx
+++ b/src/screens/database/views/query/TabsPane/index.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, Badge, Divider, ScrollArea, Stack, Tooltip } from "@mantine/core";
 import clsx from "clsx";
 import { useContextMenu } from "mantine-contextmenu";
+import { ActionButton } from "~/components/ActionButton";
 import { EditableText } from "~/components/EditableText";
 import { Entry } from "~/components/Entry";
 import { Icon } from "~/components/Icon";
@@ -28,7 +29,6 @@ import {
 	iconStar,
 } from "~/util/icons";
 import classes from "./style.module.scss";
-import { ActionButton } from "~/components/ActionButton";
 
 export interface TabsPaneProps {
 	openHistory: () => void;

--- a/src/screens/database/views/query/TabsPane/index.tsx
+++ b/src/screens/database/views/query/TabsPane/index.tsx
@@ -1,11 +1,4 @@
-import {
-	ActionIcon,
-	Badge,
-	Divider,
-	ScrollArea,
-	Stack,
-	Tooltip,
-} from "@mantine/core";
+import { ActionIcon, Badge, Divider, ScrollArea, Stack, Tooltip } from "@mantine/core";
 import clsx from "clsx";
 import { useContextMenu } from "mantine-contextmenu";
 import { EditableText } from "~/components/EditableText";
@@ -24,6 +17,7 @@ import { useInterfaceStore } from "~/stores/interface";
 import type { TabQuery } from "~/types";
 import {
 	iconArrowUpRight,
+	iconChevronLeft,
 	iconChevronRight,
 	iconClose,
 	iconCopy,
@@ -34,6 +28,7 @@ import {
 	iconStar,
 } from "~/util/icons";
 import classes from "./style.module.scss";
+import { ActionButton } from "~/components/ActionButton";
 
 export interface TabsPaneProps {
 	openHistory: () => void;
@@ -69,9 +64,7 @@ export function TabsPane(props: TabsPaneProps) {
 		for (const [i, query] of queries.entries()) {
 			if (
 				query.id !== id &&
-				(dir === 0 ||
-					(dir === -1 && i < index) ||
-					(dir === 1 && i > index))
+				(dir === 0 || (dir === -1 && i < index) || (dir === 1 && i > index))
 			) {
 				removeTab(query.id);
 			}
@@ -88,6 +81,12 @@ export function TabsPane(props: TabsPaneProps) {
 	const saveQueryOrder = useStable((queries: TabQuery[]) => {
 		updateCurrentConnection({
 			queries,
+		});
+	});
+
+	const closeQueryList = useStable(() => {
+		updateCurrentConnection({
+			queryTabList: false,
 		});
 	});
 
@@ -116,11 +115,20 @@ export function TabsPane(props: TabsPaneProps) {
 				</Badge>
 			}
 			rightSection={
-				<Tooltip label="New query">
-					<ActionIcon onClick={newTab} aria-label="Create new query">
+				<>
+					<ActionButton
+						label="Hide queries"
+						onClick={closeQueryList}
+					>
+						<Icon path={iconChevronLeft} />
+					</ActionButton>
+					<ActionButton
+						label="New query"
+						onClick={newTab}
+					>
 						<Icon path={iconPlus} />
-					</ActionIcon>
-				</Tooltip>
+					</ActionButton>
+				</>
 			}
 		>
 			<Stack
@@ -137,7 +145,10 @@ export function TabsPane(props: TabsPaneProps) {
 						viewport: classes.scroller,
 					}}
 				>
-					<Stack gap="xs" pb="md">
+					<Stack
+						gap="xs"
+						pb="md"
+					>
 						<Sortable
 							items={queries}
 							direction="vertical"
@@ -152,9 +163,7 @@ export function TabsPane(props: TabsPaneProps) {
 									<Entry
 										key={query.id}
 										isActive={isActive}
-										onClick={() =>
-											setActiveQueryTab(query.id)
-										}
+										onClick={() => setActiveQueryTab(query.id)}
 										className={clsx(
 											classes.query,
 											isDragging && classes.queryDragging,
@@ -163,20 +172,14 @@ export function TabsPane(props: TabsPaneProps) {
 											{
 												key: "open",
 												title: "Open",
-												icon: (
-													<Icon
-														path={iconArrowUpRight}
-													/>
-												),
-												onClick: () =>
-													setActiveQueryTab(query.id),
+												icon: <Icon path={iconArrowUpRight} />,
+												onClick: () => setActiveQueryTab(query.id),
 											},
 											{
 												key: "duplicate",
 												title: "Duplicate",
 												icon: <Icon path={iconCopy} />,
-												onClick: () =>
-													duplicateQuery(query),
+												onClick: () => duplicateQuery(query),
 											},
 											{
 												key: "close-div",
@@ -185,40 +188,31 @@ export function TabsPane(props: TabsPaneProps) {
 												key: "close",
 												title: "Close",
 												disabled: queries.length === 1,
-												onClick: () =>
-													removeTab(query.id),
+												onClick: () => removeTab(query.id),
 											},
 											{
 												key: "close-others",
 												title: "Close Others",
 												disabled: queries.length === 1,
-												onClick: () =>
-													removeOthers(query.id, 0),
+												onClick: () => removeOthers(query.id, 0),
 											},
 											{
 												key: "close-before",
 												title: "Close queries Before",
 												disabled:
 													queries.length === 1 ||
-													queries.findIndex(
-														(q) =>
-															q.id === query.id,
-													) === 0,
-												onClick: () =>
-													removeOthers(query.id, -1),
+													queries.findIndex((q) => q.id === query.id) ===
+														0,
+												onClick: () => removeOthers(query.id, -1),
 											},
 											{
 												key: "close-after",
 												title: "Close queries After",
 												disabled:
 													queries.length === 1 ||
-													queries.findIndex(
-														(q) =>
-															q.id === query.id,
-													) >=
+													queries.findIndex((q) => q.id === query.id) >=
 														queries.length - 1,
-												onClick: () =>
-													removeOthers(query.id, 1),
+												onClick: () => removeOthers(query.id, 1),
 											},
 										])}
 										leftSection={<Icon path={iconQuery} />}
@@ -226,14 +220,8 @@ export function TabsPane(props: TabsPaneProps) {
 											<>
 												{isLive && (
 													<LiveIndicator
-														className={
-															classes.queryLive
-														}
-														color={
-															isActive
-																? "white"
-																: "red"
-														}
+														className={classes.queryLive}
+														color={isActive ? "white" : "red"}
 														mr={-4}
 													/>
 												)}
@@ -243,15 +231,8 @@ export function TabsPane(props: TabsPaneProps) {
 														size="sm"
 														component="div"
 														variant="subtle"
-														className={
-															classes.queryClose
-														}
-														onClick={(e) =>
-															removeTab(
-																query.id,
-																e,
-															)
-														}
+														className={classes.queryClose}
+														onClick={(e) => removeTab(query.id, e)}
 														color={
 															isActive && isLight
 																? "white"
@@ -271,9 +252,7 @@ export function TabsPane(props: TabsPaneProps) {
 									>
 										<EditableText
 											value={query.name || ""}
-											onChange={(value) =>
-												renameQuery(query.id, value)
-											}
+											onChange={(value) => renameQuery(query.id, value)}
 											withDoubleClick
 											withDecoration
 											style={{

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -114,6 +114,8 @@ export interface Connection {
 	diagramDirection: DiagramDirection;
 	diagramShowLinks: boolean;
 	designerTableList: boolean;
+	explorerTableList: boolean;
+	queryTabList: boolean;
 	graphqlQuery: string;
 	graphqlVariables: string;
 	graphqlShowVariables: boolean;

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -124,6 +124,8 @@ export function createBaseConnection(settings: SurrealistSettings): Connection {
 		lastNamespace: "",
 		lastDatabase: "",
 		designerTableList: true,
+		explorerTableList: true,
+		queryTabList: true,
 		diagramMode: settings.appearance.defaultDiagramMode,
 		diagramDirection: settings.appearance.defaultDiagramDirection,
 		diagramShowLinks: settings.appearance.defaultDiagramShowLinks,


### PR DESCRIPTION
- This PR brings the Query and Explorer views in line with the Designer view which already supports this functionality.
- The explorer tables panel will always be displayed when no table is selected