### PR TITLE
feat: add sync schema button

### DIFF
--- a/src/screens/database/components/ConnectionStatus/index.tsx
+++ b/src/screens/database/components/ConnectionStatus/index.tsx
@@ -4,6 +4,7 @@ import {
 	iconDownload,
 	iconEdit,
 	iconList,
+	iconRefresh,
 	iconReset,
 	iconSandbox,
 	iconTable,
@@ -25,6 +26,7 @@ import type { Connection } from "~/types";
 import { USER_ICONS } from "~/util/user-icons";
 import { Icon } from "../../../../components/Icon";
 import { closeConnection, openConnection } from "../../connection/connection";
+import { syncConnectionSchema } from "~/util/schema";
 
 export function ConnectionStatus() {
 	const [isDropped, setIsDropped] = useState(false);
@@ -173,6 +175,12 @@ export function ConnectionStatus() {
 							</Menu.Item>
 							{!isSandbox && (
 								<>
+									<Menu.Item
+										leftSection={<Icon path={iconRefresh} />}
+										onClick={() => syncConnectionSchema()}
+									>
+										Sync schema
+									</Menu.Item>
 									<Menu.Item
 										leftSection={<Icon path={iconReset} />}
 										onClick={() => openConnection()}

--- a/src/screens/database/components/ConnectionStatus/index.tsx
+++ b/src/screens/database/components/ConnectionStatus/index.tsx
@@ -23,10 +23,10 @@ import { useStable } from "~/hooks/stable";
 import { dispatchIntent } from "~/hooks/url";
 import { useDatabaseStore } from "~/stores/database";
 import type { Connection } from "~/types";
+import { syncConnectionSchema } from "~/util/schema";
 import { USER_ICONS } from "~/util/user-icons";
 import { Icon } from "../../../../components/Icon";
 import { closeConnection, openConnection } from "../../connection/connection";
-import { syncConnectionSchema } from "~/util/schema";
 
 export function ConnectionStatus() {
 	const [isDropped, setIsDropped] = useState(false);


### PR DESCRIPTION
This pull request adds a simple button to the connection dropdown menu which syncs the schema. This is useful when tables or other resources have been created externally and need to be updated inside of Surrealist.