### PR TITLE
Add focus table context menu option

### DIFF
--- a/src/screens/database/components/TablesPane/index.tsx
+++ b/src/screens/database/components/TablesPane/index.tsx
@@ -9,8 +9,8 @@ import {
 	iconTable,
 } from "~/util/icons";
 
-import { useInputState } from "@mantine/hooks";
 import { Badge, Divider, ScrollArea, Stack, Text, TextInput } from "@mantine/core";
+import { useInputState } from "@mantine/hooks";
 import { type ContextMenuItemOptions, useContextMenu } from "mantine-contextmenu";
 import { sort } from "radash";
 import { useMemo } from "react";

--- a/src/screens/database/components/TablesPane/index.tsx
+++ b/src/screens/database/components/TablesPane/index.tsx
@@ -1,14 +1,16 @@
 import {
-	ActionIcon,
-	Badge,
-	Divider,
-	ScrollArea,
-	Stack,
-	Text,
-	TextInput,
-	Tooltip,
-} from "@mantine/core";
+	iconChevronLeft,
+	iconDelete,
+	iconPin,
+	iconPinOff,
+	iconPlus,
+	iconRelation,
+	iconSearch,
+	iconTable,
+} from "~/util/icons";
+
 import { useInputState } from "@mantine/hooks";
+import { Badge, Divider, ScrollArea, Stack, Text, TextInput } from "@mantine/core";
 import { type ContextMenuItemOptions, useContextMenu } from "mantine-contextmenu";
 import { sort } from "radash";
 import { useMemo } from "react";
@@ -25,17 +27,7 @@ import { useConfirmation } from "~/providers/Confirmation";
 import { executeQuery } from "~/screens/database/connection/connection";
 import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
-import { fuzzyMatch, fuzzyMultiMatch, tb } from "~/util/helpers";
-import {
-	iconChevronLeft,
-	iconDelete,
-	iconPin,
-	iconPinOff,
-	iconPlus,
-	iconRelation,
-	iconSearch,
-	iconTable,
-} from "~/util/icons";
+import { fuzzyMultiMatch, tb } from "~/util/helpers";
 import { extractEdgeRecords, syncConnectionSchema } from "~/util/schema";
 import classes from "./style.module.scss";
 

--- a/src/screens/database/views/designer/DesignerView/index.tsx
+++ b/src/screens/database/views/designer/DesignerView/index.tsx
@@ -8,12 +8,12 @@ import { useActiveConnection, useIsConnected } from "~/hooks/connection";
 import { usePanelMinSize } from "~/hooks/panels";
 import { useTables } from "~/hooks/schema";
 import { useStable } from "~/hooks/stable";
-import { useIntent } from "~/hooks/url";
+import { dispatchIntent, useIntent } from "~/hooks/url";
 import { useViewEffect } from "~/hooks/view";
 import { useDesigner } from "~/providers/Designer";
 import { TablesPane } from "~/screens/database/components/TablesPane";
 import { useConfigStore } from "~/stores/config";
-import { iconDesigner } from "~/util/icons";
+import { iconDesigner, iconEye } from "~/util/icons";
 import { syncConnectionSchema } from "~/util/schema";
 import { TableGraphPane } from "../TableGraphPane";
 
@@ -33,6 +33,12 @@ export function DesignerView() {
 			title: "Open designer",
 			icon: <Icon path={iconDesigner} />,
 			onClick: () => design(table),
+		},
+		{
+			key: "open",
+			title: "Focus table",
+			icon: <Icon path={iconEye} />,
+			onClick: () => dispatchIntent("focus-table", { table }),
 		},
 	]);
 

--- a/src/screens/database/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/index.tsx
@@ -90,12 +90,12 @@ import { useActiveConnection } from "~/hooks/connection";
 import { useDatabaseSchema } from "~/hooks/schema";
 import { useStable } from "~/hooks/stable";
 import { useIsLight } from "~/hooks/theme";
+import { useIntent } from "~/hooks/url";
 import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
 import { showInfo } from "~/util/helpers";
 import { themeColor } from "~/util/mantine";
 import { GraphWarningLine } from "./components";
-import { useIntent } from "~/hooks/url";
 
 export interface TableGraphPaneProps {
 	active: string | null;

--- a/src/screens/database/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/index.tsx
@@ -5,7 +5,6 @@ import {
 	Badge,
 	Box,
 	Button,
-	Checkbox,
 	Divider,
 	Group,
 	HoverCard,
@@ -19,7 +18,6 @@ import {
 } from "@mantine/core";
 
 import {
-	type ChangeEvent,
 	type ElementRef,
 	type MouseEvent,
 	useEffect,
@@ -32,7 +30,6 @@ import {
 	Background,
 	type Edge,
 	type Node,
-	type OnNodesChange,
 	ReactFlow,
 	useEdgesState,
 	useNodesInitialized,
@@ -42,7 +39,6 @@ import {
 
 import {
 	iconAPI,
-	iconChevronLeft,
 	iconChevronRight,
 	iconCog,
 	iconFullscreen,
@@ -63,15 +59,6 @@ import {
 	createSnapshot,
 } from "./helpers";
 
-import { useContextMenu } from "mantine-contextmenu";
-import { sleep } from "radash";
-import { adapter } from "~/adapter";
-import { ActionButton } from "~/components/ActionButton";
-import { Icon } from "~/components/Icon";
-import { Label } from "~/components/Label";
-import { Link } from "~/components/Link";
-import { ContentPane } from "~/components/Pane";
-import { RadioSelect } from "~/components/RadioSelect";
 import {
 	DESIGNER_ALGORITHMS,
 	DESIGNER_DIRECTIONS,
@@ -79,14 +66,7 @@ import {
 	DESIGNER_LINKS,
 	DESIGNER_NODE_MODES,
 } from "~/constants";
-import { useSetting } from "~/hooks/config";
-import { useIsConnected } from "~/hooks/connection";
-import { useActiveConnection } from "~/hooks/connection";
-import { useDatabaseSchema } from "~/hooks/schema";
-import { useStable } from "~/hooks/stable";
-import { useIsLight } from "~/hooks/theme";
-import { useConfigStore } from "~/stores/config";
-import { useInterfaceStore } from "~/stores/interface";
+
 import type {
 	DiagramAlgorithm,
 	DiagramDirection,
@@ -95,9 +75,27 @@ import type {
 	DiagramMode,
 	TableInfo,
 } from "~/types";
+
+import { useContextMenu } from "mantine-contextmenu";
+import { sleep } from "radash";
+import { adapter } from "~/adapter";
+import { ActionButton } from "~/components/ActionButton";
+import { Icon } from "~/components/Icon";
+import { Label } from "~/components/Label";
+import { Link } from "~/components/Link";
+import { ContentPane } from "~/components/Pane";
+import { useSetting } from "~/hooks/config";
+import { useIsConnected } from "~/hooks/connection";
+import { useActiveConnection } from "~/hooks/connection";
+import { useDatabaseSchema } from "~/hooks/schema";
+import { useStable } from "~/hooks/stable";
+import { useIsLight } from "~/hooks/theme";
+import { useConfigStore } from "~/stores/config";
+import { useInterfaceStore } from "~/stores/interface";
 import { showInfo } from "~/util/helpers";
 import { themeColor } from "~/util/mantine";
 import { GraphWarningLine } from "./components";
+import { useIntent } from "~/hooks/url";
 
 export interface TableGraphPaneProps {
 	active: string | null;
@@ -309,6 +307,17 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 			});
 		});
 	}, [props.active]);
+
+	useIntent("focus-table", ({ table }) => {
+		const node = getNodes().find((node) => node.id === table);
+
+		if (node) {
+			fitView({
+				nodes: [node],
+				duration: 300,
+			});
+		}
+	});
 
 	return (
 		<ContentPane

--- a/src/screens/database/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/database/views/designer/TableGraphPane/index.tsx
@@ -487,7 +487,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 							key: "view",
 							icon: <Icon path={iconFullscreen} />,
 							title: "Fit viewport",
-							onClick: () => fitView(),
+							onClick: () => fitView({ duration: 300 }),
 						},
 						{
 							key: "refresh",

--- a/src/util/intents.tsx
+++ b/src/util/intents.tsx
@@ -39,6 +39,7 @@ const INTENT_REGISTRY = {
 	"toggle-graphql-variables": "graphql",
 	"infer-graphql-variables": "graphql",
 	"design-table": "designer",
+	"focus-table": "designer",
 	"create-user": "authentication",
 	"create-access": "authentication",
 	"register-user": "authentication",


### PR DESCRIPTION
- Allows focusing a table in the table graph
- Exposed as a new `focus-table` intent
- Also added an animation to "Fit viewport"

Closes #498