### PR TITLE
Add editor shortcut to select the current query

### DIFF
--- a/src/editor/keymaps.tsx
+++ b/src/editor/keymaps.tsx
@@ -1,7 +1,7 @@
 import { redo, redoSelection, undo, undoSelection } from "@codemirror/commands";
 import type { KeyBinding } from "@codemirror/view";
 import { suggestCompletions } from "./commands";
-import { executeEditorQuery, executeGraphqlEditorQuery } from "./query";
+import { executeEditorQuery, executeGraphqlEditorQuery, selectCursorQuery } from "./query";
 
 /**
  * A custom variant of the history keymap that uses
@@ -26,6 +26,7 @@ export const customHistoryKeymap: readonly KeyBinding[] = [
 export const runQueryKeymap: readonly KeyBinding[] = [
 	{ key: "Mod-Enter", run: executeEditorQuery },
 	{ key: "F9", run: executeEditorQuery },
+	{ key: "Mod-e", run: selectCursorQuery },
 ];
 
 /**

--- a/src/editor/query.tsx
+++ b/src/editor/query.tsx
@@ -43,11 +43,13 @@ export function setQueryEditor(currentView: EditorView, queryView?: EditorView) 
  */
 export const executeEditorQuery: Command = (view: EditorView) => {
 	const editor = view.state.field(queryEditorField, false) ?? view;
-	const query = editor.state.doc.toString();
 	const selection = editor.state.selection.main;
+	const override = selection.empty
+		? undefined
+		: editor.state.sliceDoc(selection.from, selection.to);
 
 	executeUserQuery({
-		override: selection?.empty === false ? query.slice(selection.from, selection.to) : query,
+		override,
 	});
 
 	return true;
@@ -66,9 +68,11 @@ export const selectCursorQuery: Command = (view: EditorView) => {
 		view.dispatch({
 			selection,
 		});
+
+		return true;
 	}
 
-	return true;
+	return false;
 };
 
 /**

--- a/src/editor/query.tsx
+++ b/src/editor/query.tsx
@@ -1,8 +1,9 @@
-import { StateEffect, StateField } from "@codemirror/state";
+import { EditorSelection, StateEffect, StateField } from "@codemirror/state";
 import type { Command, EditorView } from "@codemirror/view";
 import { executeGraphql, executeUserQuery } from "~/screens/database/connection/connection";
 import { getActiveConnection } from "~/util/connection";
 import { tryParseParams } from "~/util/helpers";
+import { getQueryRange } from "./surrealql";
 
 const queryEditorEffect = StateEffect.define<EditorView>();
 
@@ -48,6 +49,24 @@ export const executeEditorQuery: Command = (view: EditorView) => {
 	executeUserQuery({
 		override: selection?.empty === false ? query.slice(selection.from, selection.to) : query,
 	});
+
+	return true;
+};
+
+/**
+ * Select the query the cursor is currently in
+ */
+export const selectCursorQuery: Command = (view: EditorView) => {
+	const range = getQueryRange(view);
+
+	if (range) {
+		const [from, to] = range;
+		const selection = EditorSelection.single(from, to);
+
+		view.dispatch({
+			selection,
+		});
+	}
 
 	return true;
 };

--- a/src/editor/selection.tsx
+++ b/src/editor/selection.tsx
@@ -4,9 +4,7 @@ import { EditorView } from "@codemirror/view";
 /**
  * An extension that reports on selection changes
  */
-export const selectionChanged = (
-	cb: (ranges: SelectionRange) => void,
-): Extension => {
+export const selectionChanged = (cb: (ranges: SelectionRange) => void): Extension => {
 	return EditorView.updateListener.of((update) => {
 		if (update.selectionSet) {
 			cb(update.state.selection.main);

--- a/src/editor/surrealql.tsx
+++ b/src/editor/surrealql.tsx
@@ -1,7 +1,48 @@
+import { syntaxTree } from "@codemirror/language";
 import { linter } from "@codemirror/lint";
 import type { Extension } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
 import { getSetting } from "~/util/config";
 import { validateQuery } from "~/util/surrealql";
+
+const findStatement = (stack: any): [number, number] | null => {
+	for (let cur = stack; cur; cur = cur.next) {
+		const { node } = cur;
+
+		if (node.type.is("Statement")) {
+			return [node.from, node.to];
+		}
+	}
+
+	return null;
+};
+
+/**
+ * Returns the range of the query the cursor is currently in
+ */
+export const getQueryRange = (view: EditorView): [number, number] | null => {
+	const tree = syntaxTree(view.state);
+	const cursor = view.state.selection.main.head;
+	const isTerm = view.state.sliceDoc(cursor - 1, cursor) === ";";
+
+	// Find a query to the right
+	const rightStack = tree.resolveStack(cursor, 1);
+	const rightStatement = findStatement(rightStack);
+
+	if (rightStatement) {
+		return rightStatement;
+	}
+
+	// Find a query to the left, optionally skipping a semicolon
+	const leftStack = tree.resolveStack(isTerm ? cursor - 1 : cursor, -1);
+	const leftStatement = findStatement(leftStack);
+
+	if (leftStatement) {
+		return leftStatement;
+	}
+
+	return null;
+};
 
 /**
  * SurrealQL error linting

--- a/src/screens/database/views/query/QueryPane/index.tsx
+++ b/src/screens/database/views/query/QueryPane/index.tsx
@@ -84,8 +84,8 @@ export function QueryPane({
 		try {
 			const formatted = hasSelection
 				? buffer.slice(0, selection.from) +
-				formatQuery(buffer.slice(selection.from, selection.to)) +
-				buffer.slice(selection.to)
+					formatQuery(buffer.slice(selection.from, selection.to)) +
+					buffer.slice(selection.to)
 				: formatQuery(buffer);
 
 			onUpdateBuffer(formatted);
@@ -158,7 +158,10 @@ export function QueryPane({
 			}
 			infoSection={
 				activeTab.type === "file" && (
-					<Text c="slate" truncate>
+					<Text
+						c="slate"
+						truncate
+					>
 						{trim(activeTab.query, "\\\\?")}
 					</Text>
 				)
@@ -167,7 +170,10 @@ export function QueryPane({
 				switchPortal ? (
 					<OutPortal node={switchPortal} />
 				) : (
-					<Group gap="sm" style={{ flexShrink: 0 }}>
+					<Group
+						gap="sm"
+						style={{ flexShrink: 0 }}
+					>
 						{buffer.length > MAX_HISTORY_QUERY_LENGTH && (
 							<HoverCard position="bottom">
 								<HoverCard.Target>

--- a/src/screens/database/views/query/QueryView/index.tsx
+++ b/src/screens/database/views/query/QueryView/index.tsx
@@ -31,6 +31,7 @@ import { Link } from "~/components/Link";
 import { PanelDragger } from "~/components/Pane/dragger";
 import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { Spacer } from "~/components/Spacer";
+import { executeEditorQuery } from "~/editor/query";
 import { useLogoUrl } from "~/hooks/brand";
 import { useSetting } from "~/hooks/config";
 import { useActiveConnection, useActiveQuery, useSavedQueryTags } from "~/hooks/connection";
@@ -50,7 +51,6 @@ import { SavesDrawer } from "../SavesDrawer";
 import { TabsPane } from "../TabsPane";
 import { VariablesPane } from "../VariablesPane";
 import { readQuery, writeQuery } from "./strategy";
-import { executeEditorQuery } from "~/editor/query";
 
 const switchPortal = createHtmlPortalNode();
 

--- a/src/screens/database/views/query/QueryView/index.tsx
+++ b/src/screens/database/views/query/QueryView/index.tsx
@@ -50,6 +50,7 @@ import { SavesDrawer } from "../SavesDrawer";
 import { TabsPane } from "../TabsPane";
 import { VariablesPane } from "../VariablesPane";
 import { readQuery, writeQuery } from "./strategy";
+import { executeEditorQuery } from "~/editor/query";
 
 const switchPortal = createHtmlPortalNode();
 
@@ -178,9 +179,14 @@ export function QueryView() {
 
 	useIntent("open-saved-queries", showSavedHandle.open);
 	useIntent("open-query-history", showHistoryHandle.open);
-	useIntent("run-query", executeUserQuery);
 	useIntent("save-query", handleSaveRequest);
 	useIntent("toggle-variables", () => setShowVariables(!showVariables));
+
+	useIntent("run-query", () => {
+		if (editor) {
+			executeEditorQuery(editor);
+		}
+	});
 
 	const [minSidebarSize, rootRef] = usePanelMinSize(275);
 	const [minResultHeight, wrapperRef] = usePanelMinSize(48, "height");


### PR DESCRIPTION
Added `Cmd/ctrl + E` to SurrealQL editors to select the query your cursor is located in. This is especially useful useful when combined with `Cmd/ctrl + Enter` to execute the selected query.