### PR TITLE
Fix Signup dialog using subject instead of value

### DIFF
--- a/src/components/App/modals/signup.tsx
+++ b/src/components/App/modals/signup.tsx
@@ -118,7 +118,7 @@ export function AccessSignupModal() {
 											size="xs"
 											readOnly
 											variant="unstyled"
-											value={field.subject}
+											value={field.value}
 											spellCheck={false}
 											styles={{
 												input: {


### PR DESCRIPTION
Updates the text shown under the `Value` column in the `Register with access method` dialog to use `field.value` instead of `field.subject`

Fixes #562 