### PR TITLE
[fix] correctly convert cents to unit

### DIFF
--- a/src/screens/cloud-manage/pages/Billing/index.tsx
+++ b/src/screens/cloud-manage/pages/Billing/index.tsx
@@ -453,7 +453,7 @@ export function BillingPage() {
 													{status?.name ?? invoice.status}
 												</Table.Td>
 												<Table.Td>
-													${(invoice.amount * 100).toFixed(2)} USD
+													${(invoice.amount / 100).toFixed(2)} USD
 												</Table.Td>
 												<Table.Td>
 													<Link href={invoice.url}>


### PR DESCRIPTION
the invoice Amount is reported in cents, the way to convert cents to full units is to divide by 100 not multiply by 100,
example: 350 cents = 3.50 USD (350/100)

example of invoices that look off:
![Screenshot 2024-11-14 at 14 52 09](https://github.com/user-attachments/assets/8ca1d2a7-2c86-458d-9da8-7c29c16f8e0c)
