### PR TITLE
Separate query editing history 

### DIFF
--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -88,14 +88,6 @@ export function CodeEditor(props: CodeEditorProps) {
 		});
 
 		editorRef.current = editor;
-
-		if (autoFocus) {
-			const timer = setInterval(() => {
-				editor.focus();
-				if (editor.hasFocus) clearInterval(timer);
-			}, 50);
-		}
-
 		onMount?.(editor);
 
 		return () => {
@@ -103,29 +95,7 @@ export function CodeEditor(props: CodeEditorProps) {
 		};
 	}, []);
 
-	useEffect(() => {
-		if (!editorRef.current) return;
-
-		const editor = editorRef.current;
-
-		if (value === editor.state.doc.toString()) {
-			return;
-		}
-
-		const transaction = editor.state.update({
-			changes: {
-				from: 0,
-				to: editor.state.doc.length,
-				insert: value,
-			},
-			effects: [EditorView.scrollIntoView(0)],
-		});
-
-		editor.dispatch(transaction);
-		forceLinting(editor);
-	}, [value]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Ignore extensions
+	// biome-ignore lint/correctness/useExhaustiveDependencies: Update only state
 	useEffect(() => {
 		if (!editorRef.current) return;
 
@@ -150,6 +120,29 @@ export function CodeEditor(props: CodeEditorProps) {
 		initializedRef.current = true;
 	}, [state]);
 
+	// Update textual editor contents
+	useEffect(() => {
+		if (!editorRef.current) return;
+
+		const editor = editorRef.current;
+
+		if (value === editor.state.doc.toString()) {
+			return;
+		}
+
+		const transaction = editor.state.update({
+			changes: {
+				from: 0,
+				to: editor.state.doc.length,
+				insert: value,
+			},
+			effects: [EditorView.scrollIntoView(0)],
+		});
+
+		editor.dispatch(transaction);
+		forceLinting(editor);
+	}, [value]);
+
 	// Update internal extension state
 	useEffect(() => {
 		editorRef.current?.dispatch({
@@ -163,6 +156,20 @@ export function CodeEditor(props: CodeEditorProps) {
 			effects: externalCompartment.current?.reconfigure(extensions ?? []),
 		});
 	}, [extensions]);
+
+	// Automatically focus the editor
+	useEffect(() => {
+		if (!editorRef.current) return;
+
+		const editor = editorRef.current;
+
+		if (autoFocus) {
+			const timer = setInterval(() => {
+				editor.focus();
+				if (editor.hasFocus) clearInterval(timer);
+			}, 50);
+		}
+	}, [autoFocus]);
 
 	return (
 		<Box

--- a/src/components/CodeEditor/index.tsx
+++ b/src/components/CodeEditor/index.tsx
@@ -1,17 +1,17 @@
 import { history } from "@codemirror/commands";
 import { forceLinting } from "@codemirror/lint";
 import { Compartment, EditorState, type Extension } from "@codemirror/state";
-import { EditorView, lineNumbers as renderLineNumbers, ViewUpdate } from "@codemirror/view";
+import { EditorView, ViewUpdate, lineNumbers as renderLineNumbers } from "@codemirror/view";
 import { Box, type BoxProps } from "@mantine/core";
 import clsx from "clsx";
+import equal from "fast-deep-equal";
 import { useEffect, useMemo, useRef } from "react";
 import { editorBase, editorTheme } from "~/editor";
 import { useSetting } from "~/hooks/config";
+import { useStable } from "~/hooks/stable";
 import { useTheme } from "~/hooks/theme";
 import { useConfigStore } from "~/stores/config";
 import classes from "./style.module.scss";
-import { useStable } from "~/hooks/stable";
-import equal from "fast-deep-equal";
 
 export type StateSnapshot = {
 	doc: string;

--- a/src/editor/helpers.tsx
+++ b/src/editor/helpers.tsx
@@ -1,0 +1,14 @@
+import { EditorView } from "@codemirror/view";
+
+/**
+ * Set the contents of the editor
+ *
+ * @param editor The editor to set the text of
+ * @param text The text to set the editor to
+ */
+export function setEditorText(editor: EditorView, text: string) {
+	console.trace("SET");
+	editor.dispatch({
+		changes: { from: 0, to: editor.state.doc.length, insert: text },
+	});
+}

--- a/src/editor/surrealql.tsx
+++ b/src/editor/surrealql.tsx
@@ -48,47 +48,56 @@ export const getQueryRange = (view: EditorView): [number, number] | null => {
 
 /**
  * SurrealQL error linting
+ *
+ * @param onValidate Callback to run when the query is validated
  */
-export const surqlLinting = (): Extension =>
-	linter((view) => {
-		const isEnabled = getSetting("behavior", "queryErrorChecker");
-		const content = view.state.doc.toString();
+export const surqlLinting = (onValidate?: (status: string) => void): Extension =>
+	linter(
+		(view) => {
+			const isEnabled = getSetting("behavior", "queryErrorChecker");
+			const content = view.state.doc.toString();
 
-		if (!isEnabled || !content) {
+			if (!isEnabled || !content) {
+				return [];
+			}
+
+			const message = validateQuery(content) || "";
+			const match = message.match(
+				/parse error: (failed to parse query at line (\d+) column (\d+).+)\n/i,
+			);
+
+			onValidate?.(message);
+
+			if (match) {
+				const reason = match[1].trim();
+				const lineNumber = Number.parseInt(match[2]);
+				const column = Number.parseInt(match[3]);
+
+				const position = view.state.doc.line(lineNumber).from + column - 1;
+				const word = view.state.wordAt(position);
+
+				return [
+					word
+						? {
+								from: word.from,
+								to: word.to,
+								message: reason,
+								severity: "error",
+								source: "SurrealQL",
+							}
+						: {
+								from: position,
+								to: position + 1,
+								message: reason,
+								severity: "error",
+								source: "SurrealQL",
+							},
+				];
+			}
+
 			return [];
-		}
-
-		const message = validateQuery(content) || "";
-		const match = message.match(
-			/parse error: (failed to parse query at line (\d+) column (\d+).+)\n/i,
-		);
-
-		if (match) {
-			const reason = match[1].trim();
-			const lineNumber = Number.parseInt(match[2]);
-			const column = Number.parseInt(match[3]);
-
-			const position = view.state.doc.line(lineNumber).from + column - 1;
-			const word = view.state.wordAt(position);
-
-			return [
-				word
-					? {
-							from: word.from,
-							to: word.to,
-							message: reason,
-							severity: "error",
-							source: "SurrealQL",
-						}
-					: {
-							from: position,
-							to: position + 1,
-							message: reason,
-							severity: "error",
-							source: "SurrealQL",
-						},
-			];
-		}
-
-		return [];
-	});
+		},
+		{
+			delay: 250,
+		},
+	);

--- a/src/screens/database/connection/connection.tsx
+++ b/src/screens/database/connection/connection.tsx
@@ -374,8 +374,8 @@ export async function executeUserQuery(options?: UserQueryOptions) {
 	}
 
 	const { id, variables, name } = tabQuery;
-	const buffer = useQueryStore.getState().queryBuffer;
-	const query = (options?.override || buffer).trim();
+
+	const query = getQueryOr(id, options?.override).trim();
 	const variableJson = variables
 		? decodeCbor(Value.from_string(variables).to_cbor().buffer)
 		: undefined;
@@ -452,6 +452,14 @@ export async function executeUserQuery(options?: UserQueryOptions) {
 	} finally {
 		setQueryActive(false);
 	}
+}
+
+function getQueryOr(id: string, override?: string) {
+	if (override) {
+		return override;
+	}
+
+	return useQueryStore.getState().queryState[id]?.doc ?? "";
 }
 
 function isGraphqlSupportedError(err: string) {

--- a/src/screens/database/views/query/HistoryDrawer/index.tsx
+++ b/src/screens/database/views/query/HistoryDrawer/index.tsx
@@ -11,6 +11,7 @@ import {
 	iconText,
 } from "~/util/icons";
 
+import { EditorView } from "@codemirror/view";
 import { Box, Drawer } from "@mantine/core";
 import { useInputState } from "@mantine/hooks";
 import dayjs from "dayjs";
@@ -20,12 +21,11 @@ import { CodePreview } from "~/components/CodePreview";
 import { Icon } from "~/components/Icon";
 import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { Spacer } from "~/components/Spacer";
+import { setEditorText } from "~/editor/helpers";
 import { useActiveConnection, useActiveQuery } from "~/hooks/connection";
 import { useStable } from "~/hooks/stable";
 import { useConfigStore } from "~/stores/config";
 import type { HistoryQuery } from "~/types";
-import { EditorView } from "@codemirror/view";
-import { setEditorText } from "~/editor/helpers";
 
 const MAX_PREVIEW_LENGTH = 500;
 

--- a/src/screens/database/views/query/HistoryDrawer/index.tsx
+++ b/src/screens/database/views/query/HistoryDrawer/index.tsx
@@ -24,16 +24,18 @@ import { useActiveConnection, useActiveQuery } from "~/hooks/connection";
 import { useStable } from "~/hooks/stable";
 import { useConfigStore } from "~/stores/config";
 import type { HistoryQuery } from "~/types";
+import { EditorView } from "@codemirror/view";
+import { setEditorText } from "~/editor/helpers";
 
 const MAX_PREVIEW_LENGTH = 500;
 
 interface HistoryRowProps {
 	entry: HistoryQuery;
-	onUpdateBuffer: (query: string) => void;
+	editor: EditorView;
 	onClose: () => void;
 }
 
-function HistoryRow({ entry, onUpdateBuffer, onClose }: HistoryRowProps) {
+function HistoryRow({ entry, editor, onClose }: HistoryRowProps) {
 	const { updateCurrentConnection, addQueryTab } = useConfigStore.getState();
 
 	const connection = useActiveConnection();
@@ -51,7 +53,7 @@ function HistoryRow({ entry, onUpdateBuffer, onClose }: HistoryRowProps) {
 		if (!activeTab) return;
 
 		onClose();
-		onUpdateBuffer(entry.query);
+		setEditorText(editor, entry.query);
 	});
 
 	const handleDeleteQuery = useStable(() => {
@@ -146,11 +148,11 @@ const HistoryRowLazy = memo(HistoryRow);
 
 export interface HistoryDrawerProps {
 	opened: boolean;
-	onUpdateBuffer: (query: string) => void;
+	editor: EditorView;
 	onClose: () => void;
 }
 
-export function HistoryDrawer({ opened, onUpdateBuffer, onClose }: HistoryDrawerProps) {
+export function HistoryDrawer({ opened, editor, onClose }: HistoryDrawerProps) {
 	const { updateCurrentConnection } = useConfigStore.getState();
 
 	const connection = useActiveConnection();
@@ -229,7 +231,7 @@ export function HistoryDrawer({ opened, onUpdateBuffer, onClose }: HistoryDrawer
 					<HistoryRowLazy
 						key={i}
 						entry={entry}
-						onUpdateBuffer={onUpdateBuffer}
+						editor={editor}
 						onClose={onClose}
 					/>
 				))}

--- a/src/screens/database/views/query/QueryPane/index.tsx
+++ b/src/screens/database/views/query/QueryPane/index.tsx
@@ -18,17 +18,21 @@ import {
 	iconWarning,
 } from "~/util/icons";
 
+import { historyField } from "@codemirror/commands";
 import { EditorState, Prec, type SelectionRange } from "@codemirror/state";
 import { type EditorView, keymap } from "@codemirror/view";
 import { ActionIcon, Group, HoverCard, Stack, ThemeIcon, Tooltip } from "@mantine/core";
 import { Text } from "@mantine/core";
 import { surrealql } from "@surrealdb/codemirror";
 import { trim } from "radash";
+import { useMemo, useRef } from "react";
 import { type HtmlPortalNode, OutPortal } from "react-reverse-portal";
 import { ActionButton } from "~/components/ActionButton";
 import { CodeEditor, StateSnapshot } from "~/components/CodeEditor";
 import { Icon } from "~/components/Icon";
 import { ContentPane } from "~/components/Pane";
+import { MAX_HISTORY_QUERY_LENGTH } from "~/constants";
+import { setEditorText } from "~/editor/helpers";
 import { useActiveConnection } from "~/hooks/connection";
 import { useDebouncedFunction } from "~/hooks/debounce";
 import { useDatabaseVersionLinter } from "~/hooks/editor";
@@ -40,11 +44,7 @@ import { useQueryStore } from "~/stores/query";
 import type { QueryTab } from "~/types";
 import { extractVariables, showError, tryParseParams } from "~/util/helpers";
 import { formatQuery, formatValue } from "~/util/surrealql";
-import { historyField } from "@codemirror/commands";
-import { setEditorText } from "~/editor/helpers";
-import { useMemo, useRef } from "react";
 import { readQuery, writeQuery } from "../QueryView/strategy";
-import { MAX_HISTORY_QUERY_LENGTH } from "~/constants";
 
 const SERIALIZE = {
 	history: historyField,

--- a/src/screens/database/views/query/QueryPane/index.tsx
+++ b/src/screens/database/views/query/QueryPane/index.tsx
@@ -78,7 +78,7 @@ export function QueryPane({
 	onEditorMounted,
 }: QueryPaneProps) {
 	const { updateQueryTab, updateCurrentConnection } = useConfigStore.getState();
-	const { updateQueryState } = useQueryStore.getState();
+	const { updateQueryState, setQueryValid } = useQueryStore.getState();
 	const { inspect } = useInspector();
 	const connection = useActiveConnection();
 	const surqlVersion = useDatabaseVersionLinter(editor);
@@ -180,6 +180,10 @@ export function QueryPane({
 
 	const resolveVariables = useStable(() => {
 		return Object.keys(tryParseParams(activeTab.variables));
+	});
+
+	const updateValid = useStable((status: string) => {
+		setQueryValid(!status.length);
 	});
 
 	const setSelection = useDebouncedFunction(onSelectionChange, 50);
@@ -308,7 +312,7 @@ export function QueryPane({
 				extensions={[
 					surrealql(),
 					surqlVersion,
-					surqlLinting(),
+					surqlLinting(updateValid),
 					surqlRecordLinks(inspect),
 					surqlTableCompletion(),
 					surqlVariableCompletion(resolveVariables),

--- a/src/screens/database/views/query/QueryView/index.tsx
+++ b/src/screens/database/views/query/QueryView/index.tsx
@@ -48,6 +48,9 @@ import { ResultPane } from "../ResultPane";
 import { SavesDrawer } from "../SavesDrawer";
 import { TabsPane } from "../TabsPane";
 import { VariablesPane } from "../VariablesPane";
+import { useEventSubscription } from "~/hooks/event";
+import { SetQueryEvent } from "~/util/global-events";
+import { setEditorText } from "~/editor/helpers";
 
 const switchPortal = createHtmlPortalNode();
 
@@ -150,6 +153,12 @@ export function QueryView() {
 	useIntent("run-query", () => {
 		if (editor) {
 			executeEditorQuery(editor);
+		}
+	});
+
+	useEventSubscription(SetQueryEvent, (query) => {
+		if (editor) {
+			setEditorText(editor, query);
 		}
 	});
 

--- a/src/screens/database/views/query/QueryView/index.tsx
+++ b/src/screens/database/views/query/QueryView/index.tsx
@@ -31,15 +31,18 @@ import { Link } from "~/components/Link";
 import { PanelDragger } from "~/components/Pane/dragger";
 import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { Spacer } from "~/components/Spacer";
+import { setEditorText } from "~/editor/helpers";
 import { executeEditorQuery } from "~/editor/query";
 import { useLogoUrl } from "~/hooks/brand";
 import { useSetting } from "~/hooks/config";
 import { useActiveConnection, useActiveQuery, useSavedQueryTags } from "~/hooks/connection";
+import { useEventSubscription } from "~/hooks/event";
 import { usePanelMinSize } from "~/hooks/panels";
 import { useIntent } from "~/hooks/routing";
 import { useStable } from "~/hooks/stable";
 import { useConfigStore } from "~/stores/config";
 import type { SavedQuery } from "~/types";
+import { SetQueryEvent } from "~/util/global-events";
 import { ON_FOCUS_SELECT, newId } from "~/util/helpers";
 import { iconCheck } from "~/util/icons";
 import { HistoryDrawer } from "../HistoryDrawer";
@@ -48,9 +51,6 @@ import { ResultPane } from "../ResultPane";
 import { SavesDrawer } from "../SavesDrawer";
 import { TabsPane } from "../TabsPane";
 import { VariablesPane } from "../VariablesPane";
-import { useEventSubscription } from "~/hooks/event";
-import { SetQueryEvent } from "~/util/global-events";
-import { setEditorText } from "~/editor/helpers";
 
 const switchPortal = createHtmlPortalNode();
 

--- a/src/screens/database/views/query/QueryView/index.tsx
+++ b/src/screens/database/views/query/QueryView/index.tsx
@@ -13,12 +13,12 @@ import {
 } from "@mantine/core";
 
 import type { SelectionRange } from "@codemirror/state";
-import type { EditorView } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 import { Image } from "@mantine/core";
 import { useDisclosure, useInputState } from "@mantine/hooks";
 import { surrealql } from "@surrealdb/codemirror";
 import posthog from "posthog-js";
-import { memo, useLayoutEffect, useRef, useState } from "react";
+import { memo, useState } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
 import { InPortal, createHtmlPortalNode } from "react-reverse-portal";
 import { adapter, isMini } from "~/adapter";
@@ -38,9 +38,7 @@ import { useActiveConnection, useActiveQuery, useSavedQueryTags } from "~/hooks/
 import { usePanelMinSize } from "~/hooks/panels";
 import { useIntent } from "~/hooks/routing";
 import { useStable } from "~/hooks/stable";
-import { executeUserQuery } from "~/screens/database/connection/connection";
 import { useConfigStore } from "~/stores/config";
-import { useQueryStore } from "~/stores/query";
 import type { SavedQuery } from "~/types";
 import { ON_FOCUS_SELECT, newId } from "~/util/helpers";
 import { iconCheck } from "~/util/icons";
@@ -50,7 +48,6 @@ import { ResultPane } from "../ResultPane";
 import { SavesDrawer } from "../SavesDrawer";
 import { TabsPane } from "../TabsPane";
 import { VariablesPane } from "../VariablesPane";
-import { readQuery, writeQuery } from "./strategy";
 
 const switchPortal = createHtmlPortalNode();
 
@@ -60,12 +57,11 @@ const ResultPaneLazy = memo(ResultPane);
 
 export function QueryView() {
 	const { saveQuery, updateQueryTab } = useConfigStore.getState();
-	const { updateQueryBuffer } = useQueryStore.getState();
 	const { queryTabList } = useActiveConnection();
 	const logoUrl = useLogoUrl();
 
 	const [orientation] = useSetting("appearance", "queryOrientation");
-	const [editor, setEditor] = useState<EditorView | null>(null);
+	const [editor, setEditor] = useState(new EditorView());
 	const [variablesValid, setVariablesValid] = useState(true);
 
 	const [showHistory, showHistoryHandle] = useDisclosure();
@@ -126,28 +122,6 @@ export function QueryView() {
 		posthog.capture("query_save");
 	});
 
-	const saveTasks = useRef<Map<string, any>>(new Map());
-
-	const handleUpdateBuffer = useStable((query: string) => {
-		const { queryBuffer } = useQueryStore.getState();
-
-		if (!active || query === queryBuffer) {
-			return;
-		}
-
-		const oldTask = saveTasks.current.get(active.id);
-
-		updateQueryBuffer(query);
-		clearTimeout(oldTask);
-
-		const newTask = setTimeout(() => {
-			saveTasks.current.delete(active.id);
-			writeQuery(active, query);
-		}, 500);
-
-		saveTasks.current.set(active.id, newTask);
-	});
-
 	const showVariables = !!active?.showVariables;
 
 	const setShowVariables = useStable((showVariables: boolean) => {
@@ -162,15 +136,6 @@ export function QueryView() {
 	const closeVariables = useStable(() => {
 		setShowVariables(false);
 	});
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Read query on tab change
-	useLayoutEffect(() => {
-		if (active) {
-			Promise.resolve(readQuery(active)).then((query) => {
-				updateQueryBuffer(query);
-			});
-		}
-	}, [active?.id]);
 
 	const variablesOrientation = orientation === "horizontal" ? "vertical" : "horizontal";
 
@@ -221,7 +186,6 @@ export function QueryView() {
 								lineNumbers={!hideLineNumbers}
 								onSaveQuery={handleSaveRequest}
 								setShowVariables={setShowVariables}
-								onUpdateBuffer={handleUpdateBuffer}
 								onSelectionChange={setSelection}
 								onEditorMounted={setEditor}
 							/>
@@ -241,7 +205,6 @@ export function QueryView() {
 									lineNumbers={!hideLineNumbers}
 									onSaveQuery={handleSaveRequest}
 									setShowVariables={setShowVariables}
-									onUpdateBuffer={handleUpdateBuffer}
 									onSelectionChange={setSelection}
 									onEditorMounted={setEditor}
 								/>
@@ -358,14 +321,14 @@ export function QueryView() {
 
 			<HistoryDrawer
 				opened={showHistory}
-				onUpdateBuffer={handleUpdateBuffer}
+				editor={editor}
 				onClose={showHistoryHandle.close}
 			/>
 
 			<SavesDrawer
 				opened={showSaved}
+				editor={editor}
 				onClose={showSavedHandle.close}
-				onUpdateBuffer={handleUpdateBuffer}
 				onSaveQuery={handleSaveRequest}
 				onEditQuery={handleEditRequest}
 			/>

--- a/src/screens/database/views/query/ResultPane/index.tsx
+++ b/src/screens/database/views/query/ResultPane/index.tsx
@@ -77,6 +77,7 @@ export function ResultPane({ activeTab, selection, editor, corners }: ResultPane
 	const liveTabs = useInterfaceStore((s) => s.liveTabs);
 	const isQuerying = useDatabaseStore((s) => s.isQueryActive);
 	const responseMap = useDatabaseStore((s) => s.queryResponses);
+	const isQueryValid = useQueryStore((s) => s.isQueryValid);
 
 	const isLight = useIsLight();
 	const [resultTab, setResultTab] = useState<number>(1);
@@ -87,10 +88,6 @@ export function ResultPane({ activeTab, selection, editor, corners }: ResultPane
 
 	const showCombined = resultMode === "combined" || resultMode === "live";
 	const showQueries = !showCombined && responses.length > 0;
-
-	// FIXME store validation in state
-	const isValid = true;
-	// const isValid = useQueryStore((s) => s.isBufferValid);
 	const isLive = liveTabs.has(activeTab.id);
 
 	const queryList = useMemo(() => {
@@ -263,7 +260,7 @@ export function ResultPane({ activeTab, selection, editor, corners }: ResultPane
 						size="xs"
 						radius="xs"
 						color="slate"
-						variant={isValid ? "gradient" : "light"}
+						variant={isQueryValid ? "gradient" : "light"}
 						style={{ border: "none" }}
 						className={classes.run}
 						loading={isQuerying}

--- a/src/screens/database/views/query/ResultPane/index.tsx
+++ b/src/screens/database/views/query/ResultPane/index.tsx
@@ -67,7 +67,7 @@ const PREVIEW_MODES: Record<ResultMode, React.FC<PreviewProps>> = {
 export interface ResultPaneProps {
 	activeTab: QueryTab;
 	selection: SelectionRange | undefined;
-	editor: EditorView | null;
+	editor: EditorView;
 	corners?: string;
 }
 
@@ -88,7 +88,9 @@ export function ResultPane({ activeTab, selection, editor, corners }: ResultPane
 	const showCombined = resultMode === "combined" || resultMode === "live";
 	const showQueries = !showCombined && responses.length > 0;
 
-	const isValid = useQueryStore((s) => s.isBufferValid);
+	// FIXME store validation in state
+	const isValid = true;
+	// const isValid = useQueryStore((s) => s.isBufferValid);
 	const isLive = liveTabs.has(activeTab.id);
 
 	const queryList = useMemo(() => {

--- a/src/screens/database/views/query/SavesDrawer/index.tsx
+++ b/src/screens/database/views/query/SavesDrawer/index.tsx
@@ -1,5 +1,15 @@
 import classes from "./style.module.scss";
 
+import {
+	iconClose,
+	iconDelete,
+	iconEdit,
+	iconPlus,
+	iconQuery,
+	iconSearch,
+	iconText,
+} from "~/util/icons";
+
 import { Accordion, Badge, Button, ScrollArea, Text, TextInput, Tooltip } from "@mantine/core";
 import { ActionIcon, Drawer, Group } from "@mantine/core";
 import { useInputState } from "@mantine/hooks";
@@ -13,31 +23,23 @@ import { Spacer } from "~/components/Spacer";
 import { useActiveQuery, useSavedQueryTags } from "~/hooks/connection";
 import { useStable } from "~/hooks/stable";
 import { useConfigStore } from "~/stores/config";
-import { useQueryStore } from "~/stores/query";
 import type { SavedQuery } from "~/types";
-import {
-	iconClose,
-	iconDelete,
-	iconEdit,
-	iconPlus,
-	iconQuery,
-	iconSearch,
-	iconText,
-} from "~/util/icons";
+import { EditorView } from "@codemirror/view";
+import { setEditorText } from "~/editor/helpers";
 
 export interface SavesDrawerProps {
 	opened: boolean;
+	editor: EditorView;
 	onClose: () => void;
 	onSaveQuery: () => void;
-	onUpdateBuffer: (query: string) => void;
 	onEditQuery: (query: SavedQuery) => void;
 }
 
 export function SavesDrawer({
 	opened,
+	editor,
 	onClose,
 	onSaveQuery,
-	onUpdateBuffer,
 	onEditQuery,
 }: SavesDrawerProps) {
 	const { addQueryTab, removeSavedQuery } = useConfigStore.getState();
@@ -79,7 +81,7 @@ export function SavesDrawer({
 		if (!activeTab) return;
 
 		onClose();
-		onUpdateBuffer(entry.query);
+		setEditorText(editor, entry.query);
 	});
 
 	const handleDeleteQuery = useStable((entry: SavedQuery) => {

--- a/src/screens/database/views/query/SavesDrawer/index.tsx
+++ b/src/screens/database/views/query/SavesDrawer/index.tsx
@@ -10,6 +10,7 @@ import {
 	iconText,
 } from "~/util/icons";
 
+import { EditorView } from "@codemirror/view";
 import { Accordion, Badge, Button, ScrollArea, Text, TextInput, Tooltip } from "@mantine/core";
 import { ActionIcon, Drawer, Group } from "@mantine/core";
 import { useInputState } from "@mantine/hooks";
@@ -20,12 +21,11 @@ import { CodePreview } from "~/components/CodePreview";
 import { Icon } from "~/components/Icon";
 import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { Spacer } from "~/components/Spacer";
+import { setEditorText } from "~/editor/helpers";
 import { useActiveQuery, useSavedQueryTags } from "~/hooks/connection";
 import { useStable } from "~/hooks/stable";
 import { useConfigStore } from "~/stores/config";
 import type { SavedQuery } from "~/types";
-import { EditorView } from "@codemirror/view";
-import { setEditorText } from "~/editor/helpers";
 
 export interface SavesDrawerProps {
 	opened: boolean;

--- a/src/screens/database/views/query/TabsPane/index.tsx
+++ b/src/screens/database/views/query/TabsPane/index.tsx
@@ -49,6 +49,7 @@ import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
 import type { QueryTab, QueryType } from "~/types";
 import { uniqueName } from "~/util/helpers";
+import { useQueryStore } from "~/stores/query";
 
 const TYPE_ICONS: Record<QueryType, string> = {
 	config: iconQuery,
@@ -244,6 +245,7 @@ export interface TabsPaneProps {
 }
 
 export function TabsPane(props: TabsPaneProps) {
+	const { removeQueryState } = useQueryStore.getState();
 	const { updateCurrentConnection, addQueryTab, removeQueryTab, setActiveQueryTab } =
 		useConfigStore.getState();
 
@@ -258,6 +260,7 @@ export function TabsPane(props: TabsPaneProps) {
 	const removeTab = useStable((id: string) => {
 		removeQueryTab(id);
 		cancelLiveQueries(id);
+		removeQueryState(id);
 
 		if (adapter instanceof DesktopAdapter) {
 			adapter.pruneQueryFiles();

--- a/src/screens/database/views/query/TabsPane/index.tsx
+++ b/src/screens/database/views/query/TabsPane/index.tsx
@@ -47,9 +47,9 @@ import { useIsLight } from "~/hooks/theme";
 import { cancelLiveQueries } from "~/screens/database/connection/connection";
 import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
+import { useQueryStore } from "~/stores/query";
 import type { QueryTab, QueryType } from "~/types";
 import { uniqueName } from "~/util/helpers";
-import { useQueryStore } from "~/stores/query";
 
 const TYPE_ICONS: Record<QueryType, string> = {
 	config: iconQuery,

--- a/src/screens/database/views/query/VariablesPane/index.tsx
+++ b/src/screens/database/views/query/VariablesPane/index.tsx
@@ -21,7 +21,7 @@ export interface VariablesPaneProps {
 	switchPortal?: HtmlPortalNode<any>;
 	corners?: string;
 	lineNumbers: boolean;
-	editor: EditorView | null;
+	editor: EditorView;
 	setIsValid: (isValid: boolean) => void;
 	closeVariables: () => void;
 }

--- a/src/stores/query.tsx
+++ b/src/stores/query.tsx
@@ -4,15 +4,16 @@ import { StateSnapshot } from "~/components/CodeEditor";
 
 export type QueryStore = {
 	queryState: Record<string, StateSnapshot>;
+	isQueryValid: boolean;
 
 	updateQueryState: (key: string, state: StateSnapshot) => void;
 	removeQueryState: (key: string) => void;
+	setQueryValid: (valid: boolean) => void;
 };
 
 export const useQueryStore = create<QueryStore>((set) => ({
-	queryBuffer: "",
-	isBufferValid: true,
 	queryState: {},
+	isQueryValid: true,
 
 	updateQueryState: (key, value) =>
 		set((state) => ({
@@ -23,4 +24,6 @@ export const useQueryStore = create<QueryStore>((set) => ({
 		set((state) => {
 			return { queryState: omit(state.queryState, [key]) };
 		}),
+
+	setQueryValid: (valid) => set({ isQueryValid: valid }),
 }));

--- a/src/stores/query.tsx
+++ b/src/stores/query.tsx
@@ -1,20 +1,26 @@
+import { omit } from "radash";
 import { create } from "zustand";
-import { validateQuery } from "~/util/surrealql";
+import { StateSnapshot } from "~/components/CodeEditor";
 
 export type QueryStore = {
-	queryBuffer: string;
-	isBufferValid: boolean;
+	queryState: Record<string, StateSnapshot>;
 
-	updateQueryBuffer: (queryBuffer: string) => void;
+	updateQueryState: (key: string, state: StateSnapshot) => void;
+	removeQueryState: (key: string) => void;
 };
 
 export const useQueryStore = create<QueryStore>((set) => ({
 	queryBuffer: "",
 	isBufferValid: true,
+	queryState: {},
 
-	updateQueryBuffer: (queryBuffer) =>
-		set(() => ({
-			queryBuffer,
-			isBufferValid: !validateQuery(queryBuffer),
+	updateQueryState: (key, value) =>
+		set((state) => ({
+			queryState: { ...state.queryState, [key]: value },
 		})),
+
+	removeQueryState: (key) =>
+		set((state) => {
+			return { queryState: omit(state.queryState, [key]) };
+		}),
 }));

--- a/src/util/global-events.tsx
+++ b/src/util/global-events.tsx
@@ -35,3 +35,8 @@ export const CloudAuthEvent = createEventBus();
  * Invoked when the cloud account has expired
  */
 export const CloudExpiredEvent = createEventBus();
+
+/**
+ * Set the query in the currently active query tab
+ */
+export const SetQueryEvent = createEventBus<string>();

--- a/src/util/messaging.tsx
+++ b/src/util/messaging.tsx
@@ -5,6 +5,7 @@ import { useDatabaseStore } from "~/stores/database";
 import { useQueryStore } from "~/stores/query";
 import type { ResultMode } from "~/types";
 import { getActiveQuery } from "./connection";
+import { SetQueryEvent } from "./global-events";
 
 /**
  * Handle incoming window messages
@@ -31,8 +32,7 @@ export function handleWindowMessage(event: MessageEvent) {
 			const { query, variables } = options;
 
 			if (query) {
-				// FIXME
-				// updateQueryBuffer(query);
+				SetQueryEvent.dispatch(query);
 			}
 
 			if (variables) {

--- a/src/util/messaging.tsx
+++ b/src/util/messaging.tsx
@@ -23,7 +23,6 @@ export function handleWindowMessage(event: MessageEvent) {
 		return;
 	}
 
-	const { updateQueryBuffer } = useQueryStore.getState();
 	const { updateQueryTab } = useConfigStore.getState();
 	const { clearQueryResponse } = useDatabaseStore.getState();
 
@@ -32,7 +31,8 @@ export function handleWindowMessage(event: MessageEvent) {
 			const { query, variables } = options;
 
 			if (query) {
-				updateQueryBuffer(query);
+				// FIXME
+				// updateQueryBuffer(query);
 			}
 
 			if (variables) {


### PR DESCRIPTION
- Refactor `CodeEditor` to support updating and restoring editor state
- Editor state is serialised into the store, and saved per-query
- Overhauled the inner workings of `CodeEditor` to simplify compartments
- Moved query reading logic into the `QueryPane`
- Remove editor state when the query is closed
- Added a callback to the SurrealQL linter