### PR TITLE
fix: improper placeholder text on the permissions input

### DIFF
--- a/src/components/Inputs/index.tsx
+++ b/src/components/Inputs/index.tsx
@@ -41,7 +41,7 @@ import { iconCancel, iconCheck } from "~/util/icons";
 
 export interface CodeInputProps
 	extends InputBaseProps,
-		Omit<HTMLAttributes<HTMLDivElement>, "style" | "value" | "onChange"> {
+	Omit<HTMLAttributes<HTMLDivElement>, "style" | "value" | "onChange"> {
 	value: string;
 	height?: number;
 	autoFocus?: boolean;
@@ -188,14 +188,14 @@ export function CodeInput({
 				multiline
 					? [acceptWithTab]
 					: [
-							{
-								key: "Enter",
-								run: () => {
-									onSubmit?.();
-									return true;
-								},
+						{
+							key: "Enter",
+							run: () => {
+								onSubmit?.();
+								return true;
 							},
-						],
+						},
+					],
 			),
 		);
 
@@ -261,7 +261,7 @@ export function PermissionInput({
 
 	return (
 		<CodeInput
-			placeholder="WHERE user = $auth.id"
+			placeholder="user = $auth.id"
 			multiline
 			value={textValue}
 			onChange={handleChange}


### PR DESCRIPTION
This PR fixes an incorrect placeholder text in the PermissionInput component where "WHERE" is included by mistake. This makes it appear as though you should be entering "WHERE" in your permissions string, however it is not required and actually would result in an error since "WHERE" is being placed in front of the permissions string by default.