### PR TITLE
fix: issue #634

### DIFF
--- a/src/screens/surrealist/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/surrealist/views/designer/TableGraphPane/index.tsx
@@ -392,9 +392,11 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 						shadow="sm"
 					>
 						<Popover.Target>
-							<ActionButton label="Graph options">
-								<Icon path={iconCog} />
-							</ActionButton>
+							<div>
+								<ActionButton label="Graph options">
+									<Icon path={iconCog} />
+								</ActionButton>
+							</div>
 						</Popover.Target>
 						<Popover.Dropdown maw={325}>
 							<Text


### PR DESCRIPTION
This PR fixes issue #634, in which the graph option menu appears at the top left of the page.