### PR TITLE
Fix missing explorer reveal button

### DIFF
--- a/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
+++ b/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
@@ -56,7 +56,7 @@ export interface ExplorerPaneProps {
 export function ExplorerPane({ activeTable, onCreateRecord }: ExplorerPaneProps) {
 	const { addQueryTab, updateCurrentConnection } = useConfigStore.getState();
 	const { showContextMenu } = useContextMenu();
-	const explorerTableList = useConnection((c) => c?.explorerTableList ?? []);
+	const explorerTableList = useConnection((c) => c?.explorerTableList);
 	const pagination = usePagination();
 	const [, setActiveView] = useActiveView();
 


### PR DESCRIPTION
There was an incorrect fallback value defined causing the Explorer view to sometimes not allow revealing the table list

Fixes #632 