### PR TITLE
Fix a very minor typo in the Delete Instance modal

### DIFF
--- a/src/screens/surrealist/cloud-panel/components/Instance/index.tsx
+++ b/src/screens/surrealist/cloud-panel/components/Instance/index.tsx
@@ -124,7 +124,7 @@ export function Instance({ type, value, onDelete, onConnect }: Instance) {
 				</Alert>
 			</Stack>
 		),
-		confirmText: "Deleting",
+		confirmText: "Delete",
 		title: `Delete ${value.name}`,
 		verification: value.name,
 		verifyText: "Type the instance name to confirm",


### PR DESCRIPTION
This PR changes the text of the Surreal Cloud delete instance modal from 'Deleting' to 'Delete' since the instance is not being deleted yet.