### PR TITLE
Use locale number format for rows counter

### DIFF
--- a/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
+++ b/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
@@ -252,7 +252,7 @@ export function ExplorerPane({ activeTable, onCreateRecord }: ExplorerPaneProps)
 							mr={-6}
 						/>
 						<Text lineClamp={1}>
-							{recordQuery.isLoading ? "loading..." : `${recordCount || "no"} rows`}
+							{recordQuery.isLoading ? "loading..." : `${recordCount.toLocaleString() || "no"} rows`}
 						</Text>
 					</Group>
 				)


### PR DESCRIPTION
Simple change to make the row count under the explorer view more readable.