### PR TITLE
fix hostname clipboard button in the cloud instance dashboard page

### DIFF
--- a/src/screens/surrealist/views/dashboard/DashboardView/index.tsx
+++ b/src/screens/surrealist/views/dashboard/DashboardView/index.tsx
@@ -140,13 +140,13 @@ export function DashboardView() {
 								</Group>
 								<Group gap="sm">
 									<Text fz="md">{details?.host}</Text>
-									<CopyButton value={instance ?? ""}>
+									<CopyButton value={details?.host ?? ""}>
 										{({ copied, copy }) => (
 											<ActionIcon
 												variant={copied ? "gradient" : undefined}
 												size="sm"
 												onClick={copy}
-												aria-label="Copy id to clipboard"
+												aria-label="Copy hostname to clipboard"
 											>
 												<Icon
 													path={copied ? iconCheck : iconCopy}


### PR DESCRIPTION
The button was incorrectly copying the instance id instead of the instance hostname