### PR TITLE
fix: sidekick disclaimer grammar

### DIFF
--- a/src/components/Sidekick/index.tsx
+++ b/src/components/Sidekick/index.tsx
@@ -308,7 +308,7 @@ export function Sidekick() {
 						ta="center"
 						c="slate"
 					>
-						You are chatting with an AI assistant, responses may be inaccurate.
+						You are chatting with an AI assistant. Responses may be inaccurate.
 					</Text>
 				</Box>
 			)}


### PR DESCRIPTION
This PR fixes a very minor grammar issue in the sidekick view where the disclaimer used a comma instead of a period