### PR TITLE
fix: completed referrals in light theme

### DIFF
--- a/src/screens/surrealist/pages/Referral/index.tsx
+++ b/src/screens/surrealist/pages/Referral/index.tsx
@@ -59,11 +59,13 @@ interface RewardProps extends Omit<SlabProps, "title"> {
 }
 
 function Reward({ title, description, icon, active, ...other }: RewardProps) {
+	const isLight = useIsLight();
+
 	return (
 		<Slab {...other}>
 			<Box
 				p="xl"
-				c={active ? "white" : undefined}
+				c={(!isLight && active) ? "white" : undefined}
 			>
 				<Image
 					src={icon}


### PR DESCRIPTION
This PR fixes a bug in light theme where completed referrals would change the text of the reward card to white, making them unreadable.