### PR TITLE
Improve UX for copying auth token

### DIFF
--- a/src/cloud/modals/connect-cli.tsx
+++ b/src/cloud/modals/connect-cli.tsx
@@ -32,9 +32,9 @@ interface ConnectCliModalProps {
 }
 
 export async function getInstanceAuthToken(instance: CloudInstance): Promise<string> {
-	return await fetchAPI<{ token: string; }>(
-		`/instances/${instance.id}/auth`,
-	).then((res) => res.token);
+	return await fetchAPI<{ token: string }>(`/instances/${instance.id}/auth`).then(
+		(res) => res.token,
+	);
 }
 
 function ConnectCliModal({ instance }: ConnectCliModalProps) {

--- a/src/cloud/modals/connect-cli.tsx
+++ b/src/cloud/modals/connect-cli.tsx
@@ -31,15 +31,17 @@ interface ConnectCliModalProps {
 	instance: CloudInstance;
 }
 
+export async function getInstanceAuthToken(instance: CloudInstance): Promise<string> {
+	return await fetchAPI<{ token: string; }>(
+		`/instances/${instance.id}/auth`,
+	).then((res) => res.token);
+}
+
 function ConnectCliModal({ instance }: ConnectCliModalProps) {
 	const { data, isPending } = useQuery({
 		queryKey: ["cloud", "cli"],
 		refetchInterval: 1000 * 60,
-		queryFn: async () => {
-			return fetchAPI<{ token: string }>(`/instances/${instance.id}/auth`).then(
-				(res) => res.token,
-			);
-		},
+		queryFn: async () => await getInstanceAuthToken(instance),
 	});
 
 	const endpoint = `wss://${instance.host}`;

--- a/src/cloud/modals/connect-cli.tsx
+++ b/src/cloud/modals/connect-cli.tsx
@@ -1,6 +1,7 @@
 import { Group, Skeleton, Text } from "@mantine/core";
 import { openModal } from "@mantine/modals";
 import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { fetchAPI } from "~/cloud/api";
 import { CodePreview } from "~/components/CodePreview";
 import { Icon } from "~/components/Icon";
@@ -10,7 +11,6 @@ import { PrimaryTitle } from "~/components/PrimaryTitle";
 import type { CloudInstance } from "~/types";
 import { iconConsole } from "~/util/icons";
 import { useCloudAuthTokenMutation } from "../mutations/auth";
-import { useEffect } from "react";
 
 export function openConnectCli(instance: CloudInstance) {
 	openModal({

--- a/src/cloud/mutations/auth.tsx
+++ b/src/cloud/mutations/auth.tsx
@@ -10,7 +10,9 @@ export function useCloudAuthTokenMutation(instance?: string | CloudInstance) {
 	return useMutation({
 		mutationFn: async () => {
 			if (!id) return undefined;
-			return await fetchAPI<{ token: string; }>(`/instances/${id}/auth`).then((res) => res.token);
-		}
+			return await fetchAPI<{ token: string }>(`/instances/${id}/auth`).then(
+				(res) => res.token,
+			);
+		},
 	});
 }

--- a/src/cloud/mutations/auth.tsx
+++ b/src/cloud/mutations/auth.tsx
@@ -1,0 +1,16 @@
+import { useMutation } from "@tanstack/react-query";
+import { CloudInstance } from "~/types";
+import { fetchAPI } from "../api";
+
+/**
+ * Fetch instance backups
+ */
+export function useCloudAuthTokenMutation(instance?: string | CloudInstance) {
+	const id = typeof instance === "string" ? instance : instance?.id;
+	return useMutation({
+		mutationFn: async () => {
+			if (!id) return undefined;
+			return await fetchAPI<{ token: string; }>(`/instances/${id}/auth`).then((res) => res.token);
+		}
+	});
+}

--- a/src/cloud/queries/backups.tsx
+++ b/src/cloud/queries/backups.tsx
@@ -14,7 +14,7 @@ export function useCloudBackupsQuery(instance?: string) {
 		refetchInterval: 15_000,
 		enabled: !!instance && authState === "authenticated",
 		queryFn: async () => {
-			const { db_backups } = await fetchAPI<{ db_backups: CloudBackup[] }>(
+			const { db_backups } = await fetchAPI<{ db_backups: CloudBackup[]; }>(
 				`/instances/${instance}/status`,
 			);
 

--- a/src/cloud/queries/backups.tsx
+++ b/src/cloud/queries/backups.tsx
@@ -14,7 +14,7 @@ export function useCloudBackupsQuery(instance?: string) {
 		refetchInterval: 15_000,
 		enabled: !!instance && authState === "authenticated",
 		queryFn: async () => {
-			const { db_backups } = await fetchAPI<{ db_backups: CloudBackup[]; }>(
+			const { db_backups } = await fetchAPI<{ db_backups: CloudBackup[] }>(
 				`/instances/${instance}/status`,
 			);
 

--- a/src/components/InstanceActions/index.tsx
+++ b/src/components/InstanceActions/index.tsx
@@ -3,6 +3,7 @@ import { Text } from "@mantine/core";
 import { useQueryClient } from "@tanstack/react-query";
 import { PropsWithChildren, useCallback, useMemo } from "react";
 import { fetchAPI } from "~/cloud/api";
+import { useCloudAuthTokenMutation } from "~/cloud/mutations/auth";
 import { useConnectionList } from "~/hooks/connection";
 import { useStable } from "~/hooks/stable";
 import { openConnectionEditModal } from "~/modals/edit-connection";
@@ -12,7 +13,6 @@ import { tagEvent } from "~/util/analytics";
 import { showError, showInfo } from "~/util/helpers";
 import { iconDelete, iconEdit, iconPause, iconPlay } from "~/util/icons";
 import { Icon } from "../Icon";
-import { useCloudAuthTokenMutation } from "~/cloud/mutations/auth";
 
 export interface InstanceActionsProps {
 	instance: CloudInstance;
@@ -52,7 +52,6 @@ export function InstanceActions({ instance, children }: PropsWithChildren<Instan
 	});
 
 	const handleCopyAuthToken = async () => {
-
 		const token = await authTokenMutation.mutateAsync();
 
 		if (!token) {

--- a/src/components/InstanceActions/index.tsx
+++ b/src/components/InstanceActions/index.tsx
@@ -3,6 +3,7 @@ import { Text } from "@mantine/core";
 import { useQueryClient } from "@tanstack/react-query";
 import { PropsWithChildren, useMemo } from "react";
 import { fetchAPI } from "~/cloud/api";
+import { getInstanceAuthToken } from "~/cloud/modals/connect-cli";
 import { useConnectionList } from "~/hooks/connection";
 import { useStable } from "~/hooks/stable";
 import { openConnectionEditModal } from "~/modals/edit-connection";
@@ -10,9 +11,8 @@ import { useConfirmation } from "~/providers/Confirmation";
 import { CloudInstance } from "~/types";
 import { tagEvent } from "~/util/analytics";
 import { showError, showInfo } from "~/util/helpers";
-import { iconDelete, iconEdit, iconPause, iconPlay, iconCopy } from "~/util/icons";
+import { iconCopy, iconDelete, iconEdit, iconPause, iconPlay } from "~/util/icons";
 import { Icon } from "../Icon";
-import { getInstanceAuthToken } from "~/cloud/modals/connect-cli";
 
 export interface InstanceActionsProps {
 	instance: CloudInstance;
@@ -205,11 +205,7 @@ export function InstanceActions({ instance, children }: PropsWithChildren<Instan
 				<Menu.Item onClick={handleCopyID}>Copy instance ID</Menu.Item>
 				{instance.state === "ready" ? (
 					<>
-						<Menu.Item
-							onClick={handleCopyAuthToken}
-						>
-							Copy Auth token
-						</Menu.Item>
+						<Menu.Item onClick={handleCopyAuthToken}>Copy Auth token</Menu.Item>
 						<Menu.Divider />
 						<Menu.Item
 							leftSection={<Icon path={iconPause} />}

--- a/src/components/InstanceActions/index.tsx
+++ b/src/components/InstanceActions/index.tsx
@@ -10,8 +10,9 @@ import { useConfirmation } from "~/providers/Confirmation";
 import { CloudInstance } from "~/types";
 import { tagEvent } from "~/util/analytics";
 import { showError, showInfo } from "~/util/helpers";
-import { iconDelete, iconEdit, iconPause, iconPlay } from "~/util/icons";
+import { iconDelete, iconEdit, iconPause, iconPlay, iconCopy } from "~/util/icons";
 import { Icon } from "../Icon";
+import { getInstanceAuthToken } from "~/cloud/modals/connect-cli";
 
 export interface InstanceActionsProps {
 	instance: CloudInstance;
@@ -45,6 +46,16 @@ export function InstanceActions({ instance, children }: PropsWithChildren<Instan
 			showInfo({
 				title: "Copied",
 				subtitle: "Successfully copied instance id to clipboard",
+			});
+		});
+	});
+
+	const handleCopyAuthToken = useStable(async () => {
+		const token = await getInstanceAuthToken(instance);
+		navigator.clipboard.writeText(token).then(() => {
+			showInfo({
+				title: "Copied",
+				subtitle: "Successfully copied auth token to clipboard",
 			});
 		});
 	});
@@ -194,6 +205,11 @@ export function InstanceActions({ instance, children }: PropsWithChildren<Instan
 				<Menu.Item onClick={handleCopyID}>Copy instance ID</Menu.Item>
 				{instance.state === "ready" ? (
 					<>
+						<Menu.Item
+							onClick={handleCopyAuthToken}
+						>
+							Copy Auth token
+						</Menu.Item>
 						<Menu.Divider />
 						<Menu.Item
 							leftSection={<Icon path={iconPause} />}


### PR DESCRIPTION
There is not an easy way for to copy an auth token of a cloud instance in Surrealist. You have to open an CLI modal and then manually select the token field which can be painful.

This PR makes sure you can copy the auth token in 2 clicks on the overview page of the cloud instance.