### PR TITLE
Fix broken `serve` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ setup:
 	bun install
 
 .PHONY: serve
-serve: build-embed
+serve:
 	@echo "Serving..."
 	bun tauri:dev
 


### PR DESCRIPTION
Small change to fix the Makefile which was using a non-existent target as a dependency of the `serve` target.

## Verification Evidence
<img width="505" alt="Screenshot 2025-04-14 at 12 47 47 PM" src="https://github.com/user-attachments/assets/909cf06e-e68b-4b42-98df-447b8dc0ebd9" />
<img width="1435" alt="Screenshot 2025-04-14 at 12 47 58 PM" src="https://github.com/user-attachments/assets/b76a16be-c4d3-4f3d-bf90-13a6ff36e289" />
