### PR TITLE
Add API endpoint to the capabilities configurator

### DIFF
--- a/src/screens/surrealist/views/dashboard/ConfiguratorDrawer/capabilities/registry.tsx
+++ b/src/screens/surrealist/views/dashboard/ConfiguratorDrawer/capabilities/registry.tsx
@@ -44,6 +44,7 @@ export const ENDPOINT_TARGETS = [
 	{ label: "SQL", value: "sql" },
 	{ label: "GraphQL", value: "graphql" },
 	{ label: "ML", value: "ml" },
+	{ label: "API", value: "api" },
 ];
 
 /**


### PR DESCRIPTION
This PR adds the API endpoint to the capabilities configurator, allowing you to enable the '/api' endpoint related to the define API functionality in SurrealDB Cloud.