### PR TITLE
Show error on payment url failure

### DIFF
--- a/src/screens/surrealist/pages/OrganizationManage/tabs/billing.tsx
+++ b/src/screens/surrealist/pages/OrganizationManage/tabs/billing.tsx
@@ -60,6 +60,11 @@ export function OrganizationBillingTab({ organization }: OrganizationTabProps) {
 			const url = await fetchAPI<string>(`/organizations/${organization?.id}/payment/url`);
 
 			adapter.openUrl(url);
+		} catch (err: any) {
+			showError({
+				title: "Failed to open payment page",
+				subtitle: err.message,
+			});
 		} finally {
 			setRequesting(false);
 		}


### PR DESCRIPTION
Currently errors are not handled. This will be improved in a followup PR improving the showError function