### PR TITLE
Fix readonly cloud endpoints and improve docker support

### DIFF
--- a/public/instance.json
+++ b/public/instance.json
@@ -7,8 +7,6 @@
 		}
 	],
 	"cloud": {
-		"enabled": true,
-		"auth_endpoint": "https://auth.example.com",
-		"api_endpoint": "https://api.example.com"
+		"enabled": false
 	}
 }

--- a/public/instance.json
+++ b/public/instance.json
@@ -5,5 +5,10 @@
 			"id": "example",
 			"name": "Example connection"
 		}
-	]
+	],
+	"cloud": {
+		"enabled": true,
+		"auth_endpoint": "https://auth.example.com",
+		"api_endpoint": "https://api.example.com"
+	}
 }

--- a/src/adapter/docker.tsx
+++ b/src/adapter/docker.tsx
@@ -12,6 +12,10 @@ import { BrowserAdapter } from "./browser";
 export class DockerAdapter extends BrowserAdapter {
 	public readonly id: string = "docker";
 
+	public cloudEnabled = false;
+	public cloudAuthEndpoint = "";
+	public cloudApiEndpoint = "";
+
 	public async processConfig(config: SurrealistConfig) {
 		this.log("Adapter", "Fetching instance config");
 
@@ -91,6 +95,20 @@ export class DockerAdapter extends BrowserAdapter {
 		config.connections = config.connections.filter(
 			(c) => !c.instance || instanceConfig.connections.some((ic) => ic.id === c.id),
 		);
+
+		// Cloud configuration
+		const { enabled, api_endpoint, auth_endpoint } = instanceConfig.cloud ?? {};
+
+		this.cloudEnabled = enabled ?? false;
+		this.cloudAuthEndpoint = auth_endpoint ?? "";
+		this.cloudApiEndpoint = api_endpoint ?? "";
+
+		config.settings.cloud.urlAuthBase = this.cloudAuthEndpoint;
+		config.settings.cloud.urlApiBase = this.cloudApiEndpoint;
+
+		config.featureFlags.cloud_enabled = this.cloudEnabled;
+		config.featureFlags.cloud_endpoints =
+			auth_endpoint && api_endpoint ? "custom" : "production";
 
 		return config;
 	}

--- a/src/schemas.tsx
+++ b/src/schemas.tsx
@@ -39,6 +39,13 @@ export const InstanceConfigSchema = v.object({
 		),
 		[],
 	),
+	cloud: v.optional(
+		v.object({
+			enabled: v.optional(v.boolean(), false),
+			auth_endpoint: v.optional(v.string()),
+			api_endpoint: v.optional(v.string()),
+		}),
+	),
 });
 
 export type InstanceConfig = v.InferOutput<typeof InstanceConfigSchema>;

--- a/src/util/feature-flags.tsx
+++ b/src/util/feature-flags.tsx
@@ -158,10 +158,6 @@ export const featureFlags = new FeatureFlags({
 		if (value) {
 			return JSON.parse(value);
 		}
-
-		if (flag === "cloud_enabled") {
-			return import.meta.env.VITE_SURREALIST_DOCKER !== "true";
-		}
 	},
 });
 

--- a/src/util/feature-flags.tsx
+++ b/src/util/feature-flags.tsx
@@ -4,7 +4,7 @@ import {
 	type TFeatureFlags,
 } from "@theopensource-company/feature-flags";
 import { featureFlagsHookFactory } from "@theopensource-company/feature-flags/react";
-import { environment, isProduction } from "./environment";
+import { environment } from "./environment";
 
 // How to manage feature flag schema:
 // https://github.com/theopensource-company/feature-flags?tab=readme-ov-file#writing-a-schema
@@ -62,7 +62,6 @@ export const schema = {
 	},
 	cloud_endpoints: {
 		options: ["production", "custom"],
-		readonly: isProduction,
 	},
 	cloud_access: {
 		options: [false, true],


### PR DESCRIPTION
Removed the readonly status of cloud endpoints to ease internal testing, and also allow enabling cloud functionality in self hosted docker environments