### PR TITLE
Bump copyright year

### DIFF
--- a/.aws/beta/viewer-request/Makefile
+++ b/.aws/beta/viewer-request/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2024 SurrealDB Ltd
+# Copyright © 2025 SurrealDB Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.aws/dev/viewer-request/Makefile
+++ b/.aws/dev/viewer-request/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2024 SurrealDB Ltd
+# Copyright © 2025 SurrealDB Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.aws/prod/origin-request/Makefile
+++ b/.aws/prod/origin-request/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2024 SurrealDB Ltd
+# Copyright © 2025 SurrealDB Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.aws/prod/viewer-request/Makefile
+++ b/.aws/prod/viewer-request/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2024 SurrealDB Ltd
+# Copyright © 2025 SurrealDB Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 © SurrealDB Ltd
+Copyright 2025 © SurrealDB Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2024 SurrealDB Ltd
+# Copyright © 2025 SurrealDB Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/components/App/settings/tabs/About.tsx
+++ b/src/components/App/settings/tabs/About.tsx
@@ -13,6 +13,7 @@ import { isDevelopment, isPreview } from "~/util/environment";
 import { iconCheck, iconReset, iconWrench } from "~/util/icons";
 
 export function AboutTab() {
+	const currDate = new Date();
 	const [copyDebug, clipboard] = useVersionCopy();
 	const [isChecking, setChecking] = useState(false);
 
@@ -49,7 +50,7 @@ export function AboutTab() {
 
 	return (
 		<>
-			<Text c="slate">Surrealist &copy; 2024 SurrealDB Ltd</Text>
+			<Text c="slate">Surrealist &copy; {format(currDate, "yyyy")} SurrealDB Ltd</Text>
 			<Stack
 				gap="xs"
 				mt="xl"


### PR DESCRIPTION
This PR makes a few small changes in which the 2024 copyright year is updated to 2025 in multiple places. Additionally, this PR implements a dynamic year which always displays the current year in the about page, ensuring that the copyright is always up to date there.