### PR TITLE
Allow saving records and tables without closing inspector

### DIFF
--- a/src/components/SaveBox/index.tsx
+++ b/src/components/SaveBox/index.tsx
@@ -13,7 +13,7 @@ export interface SaveBoxProps {
 	inline?: boolean;
 	inlineProps?: GroupProps;
 	minimal?: boolean;
-	allowApply?: boolean;
+	withApply?: boolean;
 	position?: "left" | "center" | "right";
 	saveText?: ReactNode;
 	applyText?: ReactNode;
@@ -31,7 +31,7 @@ export function SaveBox({
 	position,
 	saveText,
 	minimal,
-	allowApply,
+	withApply,
 	applyText,
 	revertText,
 }: SaveBoxProps) {
@@ -86,14 +86,14 @@ export function SaveBox({
 				{revertButton}
 				{!minimal && <Spacer />}
 
-				{(allowApply || !minimal) && (
+				{(withApply || !minimal) && (
 					<Button.Group>
-						{allowApply && applyButton}
+						{withApply && applyButton}
 						{saveButton}
 					</Button.Group>
 				)}
 
-				{!allowApply && minimal && saveButton}
+				{!withApply && minimal && saveButton}
 			</Group>
 		);
 	}
@@ -133,7 +133,7 @@ export function SaveBox({
 					{revertButton}
 					<Spacer />
 					<Button.Group>
-						{allowApply && applyButton}
+						{withApply && applyButton}
 						{saveButton}
 					</Button.Group>
 				</Group>

--- a/src/components/SaveBox/index.tsx
+++ b/src/components/SaveBox/index.tsx
@@ -3,7 +3,7 @@ import { clsx } from "clsx";
 import { capitalize } from "radash";
 import type { ReactNode } from "react";
 import type { SaveableHandle } from "~/hooks/save";
-import { iconCheck, iconHelp } from "~/util/icons";
+import { iconCheck, iconHelp, iconReset } from "~/util/icons";
 import { Icon } from "../Icon";
 import { Spacer } from "../Spacer";
 import classes from "./style.module.scss";
@@ -12,8 +12,11 @@ export interface SaveBoxProps {
 	handle: SaveableHandle;
 	inline?: boolean;
 	inlineProps?: GroupProps;
+	minimal?: boolean;
+	allowApply?: boolean;
 	position?: "left" | "center" | "right";
 	saveText?: ReactNode;
+	applyText?: ReactNode;
 	revertText?: ReactNode;
 }
 
@@ -27,28 +30,48 @@ export function SaveBox({
 	inlineProps,
 	position,
 	saveText,
+	minimal,
+	allowApply,
+	applyText,
 	revertText,
 }: SaveBoxProps) {
 	const saveButton = (
 		<Button
+			w={minimal ? undefined : 125}
 			rightSection={<Icon path={iconCheck} />}
 			variant="gradient"
 			loading={handle.isSaving}
 			disabled={!handle.isSaveable}
-			onClick={handle.save}
+			onClick={() => handle.save()}
+			px={!minimal ? 32 : undefined}
 		>
-			{saveText ?? "Save changes"}
+			{saveText ?? (minimal ? "Save changes" : "Save")}
+		</Button>
+	);
+
+	const applyButton = (
+		<Button
+			w={minimal ? undefined : 125}
+			color="slate"
+			variant="light"
+			loading={handle.isSaving}
+			disabled={!handle.isSaveable}
+			onClick={() => handle.save(true)}
+			px={!minimal ? 32 : undefined}
+		>
+			{applyText ?? "Apply"}
 		</Button>
 	);
 
 	const revertButton = (
 		<Button
+			maw={minimal ? undefined : 150}
 			disabled={!handle.isChanged}
 			onClick={handle.revert}
 			color="slate"
 			variant="light"
 		>
-			{revertText ?? "Revert"}
+			{revertText ?? (minimal ? "Revert" : "Revert changes")}
 		</Button>
 	);
 
@@ -61,7 +84,16 @@ export function SaveBox({
 				{...inlineProps}
 			>
 				{revertButton}
-				{saveButton}
+				{!minimal && <Spacer />}
+
+				{(allowApply || !minimal) && (
+					<Button.Group>
+						{allowApply && applyButton}
+						{saveButton}
+					</Button.Group>
+				)}
+
+				{!allowApply && minimal && saveButton}
 			</Group>
 		);
 	}
@@ -99,7 +131,11 @@ export function SaveBox({
 					There are unsaved changes
 					<Spacer />
 					{revertButton}
-					{saveButton}
+					<Spacer />
+					<Button.Group>
+						{allowApply && applyButton}
+						{saveButton}
+					</Button.Group>
 				</Group>
 			</Notification>
 		</Portal>

--- a/src/components/SaveBox/index.tsx
+++ b/src/components/SaveBox/index.tsx
@@ -42,7 +42,7 @@ export function SaveBox({
 			variant="gradient"
 			loading={handle.isSaving}
 			disabled={!handle.isSaveable}
-			onClick={() => handle.save()}
+			onClick={() => handle.save(false)}
 			px={!minimal ? 32 : undefined}
 		>
 			{saveText ?? (minimal ? "Save changes" : "Save")}

--- a/src/hooks/save.ts
+++ b/src/hooks/save.ts
@@ -22,7 +22,7 @@ export interface SaveableOptions<T> {
 	 *
 	 * @param original The original state
 	 */
-	onSave: (original: T) => Task | Task<boolean>;
+	onSave: (original: T, isApply?: boolean) => Task | Task<boolean>;
 
 	/**
 	 * Called when the current state should be reverted
@@ -61,7 +61,7 @@ export interface SaveableHandle {
 	 * After onSave is complete, the tracked state will be scheduled
 	 * to be refreshed after the current render cycle.
 	 */
-	save: () => Promise<void>;
+	save: (isApply?: boolean) => Promise<void>;
 
 	/**
 	 * Revert the current state and invoke the onRevert callback.
@@ -95,10 +95,10 @@ export function useSaveable<T extends Record<string, any>>(
 		setSkipTrack(false);
 	});
 
-	const save = useStable(async () => {
+	const save = useStable(async (isApply?: boolean) => {
 		setIsSaving(true);
 
-		const result = await options.onSave(original);
+		const result = await options.onSave(original, isApply);
 
 		setIsSaving(false);
 

--- a/src/providers/Designer/drawer.tsx
+++ b/src/providers/Designer/drawer.tsx
@@ -237,13 +237,16 @@ export function DesignDrawer({
 				</Accordion>
 			</ScrollArea>
 			<Box mt="lg">
-				<SaveBox
-					handle={handle}
-					inline
-					inlineProps={{
-						className: classes.saveBox,
-					}}
-				/>
+				{handle.isChanged && (
+					<SaveBox
+						handle={handle}
+						inline
+						allowApply
+						inlineProps={{
+							className: classes.saveBox,
+						}}
+					/>
+				)}
 			</Box>
 		</Drawer>
 	);

--- a/src/providers/Designer/drawer.tsx
+++ b/src/providers/Designer/drawer.tsx
@@ -241,7 +241,7 @@ export function DesignDrawer({
 					<SaveBox
 						handle={handle}
 						inline
-						allowApply
+						withApply
 						inlineProps={{
 							className: classes.saveBox,
 						}}

--- a/src/providers/Designer/index.tsx
+++ b/src/providers/Designer/index.tsx
@@ -100,7 +100,7 @@ export function DesignerProvider({ children }: PropsWithChildren) {
 		track: {
 			data,
 		},
-		onSave: async ({ data: previous }) => {
+		onSave: async ({ data: previous }, isApply) => {
 			if (!previous) {
 				throw new Error("Could not determine previous state");
 			}
@@ -131,7 +131,9 @@ export function DesignerProvider({ children }: PropsWithChildren) {
 					tables: [data.schema.name],
 				});
 
-				designingHandle.close();
+				if (!isApply) {
+					designingHandle.close();
+				}
 			} catch (err: any) {
 				showError({
 					title: "Failed to apply schema",

--- a/src/providers/Inspector/drawer.tsx
+++ b/src/providers/Inspector/drawer.tsx
@@ -73,7 +73,7 @@ export function InspectorDrawer({ opened, history, onClose, onRefresh }: Inspect
 			setRecordBody(original.recordBody);
 			setError("");
 		},
-		onSave: async () => {
+		onSave: async (original, isApply) => {
 			const id = history.current;
 
 			const [{ success, result }] = await executeQuery(
@@ -90,7 +90,10 @@ export function InspectorDrawer({ opened, history, onClose, onRefresh }: Inspect
 			}
 
 			onRefresh();
-			onClose();
+
+			if (!isApply) {
+				onClose();
+			}
 		},
 	});
 

--- a/src/providers/Inspector/tabs/content.tsx
+++ b/src/providers/Inspector/tabs/content.tsx
@@ -59,6 +59,7 @@ export function ContentTab({ value, error, onChange, saveHandle }: ContentTabPro
 				<SaveBox
 					handle={saveHandle}
 					inline
+					allowApply
 					inlineProps={{
 						className: classes.saveBox,
 					}}

--- a/src/providers/Inspector/tabs/content.tsx
+++ b/src/providers/Inspector/tabs/content.tsx
@@ -59,7 +59,7 @@ export function ContentTab({ value, error, onChange, saveHandle }: ContentTabPro
 				<SaveBox
 					handle={saveHandle}
 					inline
-					allowApply
+					withApply
 					inlineProps={{
 						className: classes.saveBox,
 					}}

--- a/src/screens/surrealist/views/functions/EditorPanel/index.tsx
+++ b/src/screens/surrealist/views/functions/EditorPanel/index.tsx
@@ -410,7 +410,7 @@ export function EditorPanel({
 							<Button
 								variant="gradient"
 								rightSection={<Icon path={iconPlus} />}
-								onClick={handle.save}
+								onClick={() => handle.save()}
 								style={{ flexShrink: 0 }}
 							>
 								Create function
@@ -419,6 +419,7 @@ export function EditorPanel({
 							<SaveBox
 								handle={handle}
 								inline
+								minimal
 								inlineProps={{
 									className: classes.saveBox,
 								}}


### PR DESCRIPTION
This PR adds an apply button next to the save button which applies changes but doesn't close the drawer in the record inspector and table designer.

<img width="339" alt="Screenshot 2025-05-21 at 1 56 13 PM" src="https://github.com/user-attachments/assets/6d5b262f-b858-48ed-9cc1-00003584b6f4" />

Closes #779