### PR TITLE
Fix large IDs overflowing

### DIFF
--- a/src/providers/Inspector/style.module.scss
+++ b/src/providers/Inspector/style.module.scss
@@ -16,5 +16,4 @@
 .record-input {
 	font-family: "JetBrains Mono";
 	font-size: 14px;
-	height: 42px;
 }


### PR DESCRIPTION
This PR fixes a bug where large IDs would overflow to the next line without resizing the input box, causing them to be cut off.

Closes #793