### PR TITLE
Fix page being out of range in explorer view

### DIFF
--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -38,6 +38,12 @@ export function Pagination({ store, loading }: PaginationProps) {
 		setCustomPage(store.currentPage.toString());
 	}, [store.currentPage]);
 
+	useLayoutEffect(() => {
+		if (store.pageCount > 0 && store.currentPage > store.pageCount) {
+			store.setCurrentPage(store.pageCount);
+		}
+	}, [store.currentPage, store.pageCount, store.setCurrentPage]);
+
 	return (
 		<>
 			<Group


### PR DESCRIPTION
This PR fixes a bug in which your current page in the explorer view can be above the total number of pages, caused usually when all records are deleted on a page without switching to another page.

Closes #806