### PR TITLE
Improve namespace and database selection behavior

### DIFF
--- a/src/screens/surrealist/components/DatabaseList/index.tsx
+++ b/src/screens/surrealist/components/DatabaseList/index.tsx
@@ -155,7 +155,7 @@ export function DatabaseList({ buttonProps }: DatabaseListProps) {
 			opened={opened}
 			onChange={openHandle.set}
 			trigger="click"
-			position="bottom"
+			position="bottom-start"
 			transitionProps={{
 				transition: "scale-y",
 			}}

--- a/src/screens/surrealist/components/DatabaseList/index.tsx
+++ b/src/screens/surrealist/components/DatabaseList/index.tsx
@@ -5,6 +5,7 @@ import {
 	type ButtonProps,
 	Divider,
 	Group,
+	Loader,
 	Menu,
 	ScrollArea,
 	Stack,
@@ -17,6 +18,7 @@ import { escapeIdent } from "surrealdb";
 import { ActionButton } from "~/components/ActionButton";
 import { Entry } from "~/components/Entry";
 import { Icon } from "~/components/Icon";
+import { Spacer } from "~/components/Spacer";
 import { useBoolean } from "~/hooks/boolean";
 import { useConnection, useIsConnected } from "~/hooks/connection";
 import { useNamespaceSchema } from "~/hooks/schema";
@@ -114,12 +116,14 @@ export function DatabaseList({ buttonProps }: DatabaseListProps) {
 		return schema.databases.map((db) => parseIdent(db.name));
 	}, [schema, authentication]);
 
-	const openDatabase = useStable(async (db: string) => {
-		if (database !== db) {
-			await activateDatabase(namespace, db);
-		}
+	const { mutate, isPending } = useMutation({
+		mutationFn: async (db: string) => {
+			if (database !== db) {
+				await activateDatabase(namespace, db);
+			}
 
-		openHandle.close();
+			openHandle.close();
+		},
 	});
 
 	const openCreator = useStable(() => {
@@ -178,14 +182,15 @@ export function DatabaseList({ buttonProps }: DatabaseListProps) {
 					flex={1}
 					p="sm"
 				>
-					<Group>
+					<Group gap="sm">
 						<Text
-							flex={1}
 							fw={600}
 							c="bright"
 						>
 							Databases
 						</Text>
+						{isPending && <Loader size={14} />}
+						<Spacer />
 						<ActionButton
 							color="slate"
 							variant="light"
@@ -208,7 +213,7 @@ export function DatabaseList({ buttonProps }: DatabaseListProps) {
 										value={db}
 										activeNamespace={namespace}
 										activeDatabase={database}
-										onOpen={() => openDatabase(db)}
+										onOpen={mutate}
 										onRemove={openHandle.close}
 									/>
 								))}

--- a/src/screens/surrealist/components/NamespaceList/index.tsx
+++ b/src/screens/surrealist/components/NamespaceList/index.tsx
@@ -153,7 +153,7 @@ export function NamespaceList({ buttonProps }: NamespaceListProps) {
 			opened={opened}
 			onChange={openHandle.set}
 			trigger="click"
-			position="bottom"
+			position="bottom-start"
 			transitionProps={{
 				transition: "scale-y",
 			}}

--- a/src/screens/surrealist/components/NamespaceList/index.tsx
+++ b/src/screens/surrealist/components/NamespaceList/index.tsx
@@ -5,17 +5,20 @@ import {
 	type ButtonProps,
 	Divider,
 	Group,
+	Loader,
 	Menu,
 	ScrollArea,
 	Stack,
 	Text,
 } from "@mantine/core";
 
+import { useMutation } from "@tanstack/react-query";
 import { type SyntheticEvent, useMemo } from "react";
 import { escapeIdent } from "surrealdb";
 import { ActionButton } from "~/components/ActionButton";
 import { Entry } from "~/components/Entry";
 import { Icon } from "~/components/Icon";
+import { Spacer } from "~/components/Spacer";
 import { useBoolean } from "~/hooks/boolean";
 import { useConnection, useIsConnected } from "~/hooks/connection";
 import { useRootSchema } from "~/hooks/schema";
@@ -111,12 +114,14 @@ export function NamespaceList({ buttonProps }: NamespaceListProps) {
 		return schema.namespaces.map((ns) => parseIdent(ns.name));
 	}, [schema, authentication]);
 
-	const openNamespace = useStable(async (ns: string) => {
-		if (namespace !== ns) {
-			await activateDatabase(ns, "");
-		}
+	const { mutate, isPending } = useMutation({
+		mutationFn: async (ns: string) => {
+			if (namespace !== ns) {
+				await activateDatabase(ns, "");
+			}
 
-		openHandle.close();
+			openHandle.close();
+		},
 	});
 
 	const openCreator = useStable(() => {
@@ -176,14 +181,15 @@ export function NamespaceList({ buttonProps }: NamespaceListProps) {
 					p="sm"
 					gap="sm"
 				>
-					<Group>
+					<Group gap="sm">
 						<Text
-							flex={1}
 							fw={600}
 							c="bright"
 						>
 							Namespaces
 						</Text>
+						{isPending && <Loader size={14} />}
+						<Spacer />
 						<ActionButton
 							color="slate"
 							variant="light"
@@ -205,7 +211,7 @@ export function NamespaceList({ buttonProps }: NamespaceListProps) {
 										key={ns}
 										value={ns}
 										activeNamespace={namespace}
-										onOpen={openNamespace}
+										onOpen={mutate}
 										onRemove={openHandle.close}
 									/>
 								))}

--- a/src/screens/surrealist/connection/connection.tsx
+++ b/src/screens/surrealist/connection/connection.tsx
@@ -34,7 +34,7 @@ import { tagEvent } from "~/util/analytics";
 import { getActiveConnection, getAuthDB, getAuthNS, getConnection } from "~/util/connection";
 import { surqlDurationToSeconds } from "~/util/duration";
 import { CloudError } from "~/util/errors";
-import { ConnectedEvent, DisconnectedEvent } from "~/util/global-events";
+import { ConnectedEvent, ActivateDatabaseEvent, DisconnectedEvent } from "~/util/global-events";
 import { connectionUri, newId, showError, showWarning } from "~/util/helpers";
 import { syncConnectionSchema } from "~/util/schema";
 import { getLiveQueries, parseIdent } from "~/util/surrealql";
@@ -666,7 +666,11 @@ export async function activateDatabase(namespace: string, database: string) {
 	}
 
 	try {
-		await syncConnectionSchema();
+		ActivateDatabaseEvent.dispatch(null);
+
+		await syncConnectionSchema({
+			clearDatabase: true,
+		});
 	} catch (err: any) {
 		showError({
 			title: "Failed to parse schema",

--- a/src/screens/surrealist/connection/connection.tsx
+++ b/src/screens/surrealist/connection/connection.tsx
@@ -34,7 +34,7 @@ import { tagEvent } from "~/util/analytics";
 import { getActiveConnection, getAuthDB, getAuthNS, getConnection } from "~/util/connection";
 import { surqlDurationToSeconds } from "~/util/duration";
 import { CloudError } from "~/util/errors";
-import { ConnectedEvent, ActivateDatabaseEvent, DisconnectedEvent } from "~/util/global-events";
+import { ActivateDatabaseEvent, ConnectedEvent, DisconnectedEvent } from "~/util/global-events";
 import { connectionUri, newId, showError, showWarning } from "~/util/helpers";
 import { syncConnectionSchema } from "~/util/schema";
 import { getLiveQueries, parseIdent } from "~/util/surrealql";

--- a/src/screens/surrealist/views/explorer/ExplorerView/index.tsx
+++ b/src/screens/surrealist/views/explorer/ExplorerView/index.tsx
@@ -27,7 +27,7 @@ import { useDesigner } from "~/providers/Designer";
 import { TablesPane } from "~/screens/surrealist/components/TablesPane";
 import { useConfigStore } from "~/stores/config";
 import { useInterfaceStore } from "~/stores/interface";
-import { DisconnectedEvent } from "~/util/global-events";
+import { ActivateDatabaseEvent, DisconnectedEvent } from "~/util/global-events";
 import { dispatchIntent } from "~/util/intents";
 import { syncConnectionSchema } from "~/util/schema";
 import { CreatorDrawer } from "../CreatorDrawer";
@@ -85,10 +85,13 @@ export function ExplorerView() {
 		});
 	});
 
-	useEventSubscription(DisconnectedEvent, () => {
+	const resetTable = useStable(() => {
 		isCreatingHandle.close();
 		setActiveTable(undefined);
 	});
+
+	useEventSubscription(DisconnectedEvent, resetTable);
+	useEventSubscription(ActivateDatabaseEvent, resetTable);
 
 	useIntent("explore-table", ({ table }) => {
 		setActiveTable(table);

--- a/src/util/global-events.tsx
+++ b/src/util/global-events.tsx
@@ -12,6 +12,11 @@ export const ConnectedEvent = createEventBus();
 export const DisconnectedEvent = createEventBus();
 
 /**
+ * Invoked when a database and namespace is activated
+ */
+export const ActivateDatabaseEvent = createEventBus();
+
+/**
  * Invoked when records in the database have been altered
  */
 export const RecordsChangedEvent = createEventBus();


### PR DESCRIPTION
- Display a loading indicator as the schema is being retrieved
- Align namespace and database dropdowns to the left to prevent content shift
- Reset the explorer view when the connection, namespace, or database changes

Closes #807