### PR TITLE
Fix namespace and database fields being blank

### DIFF
--- a/src/modals/create-database.tsx
+++ b/src/modals/create-database.tsx
@@ -73,6 +73,7 @@ function CreateDatabase() {
 						variant="gradient"
 						flex={1}
 						loading={isPending}
+						disabled={!databaseName}
 						rightSection={<Icon path={iconPlus} />}
 					>
 						Create

--- a/src/modals/create-namespace.tsx
+++ b/src/modals/create-namespace.tsx
@@ -69,6 +69,7 @@ function CreateNamespace() {
 						variant="gradient"
 						flex={1}
 						loading={isPending}
+						disabled={!namespaceName}
 						rightSection={<Icon path={iconPlus} />}
 					>
 						Create


### PR DESCRIPTION
This PR fixes a bug where namespace and database fields can be left blank, resulting in a blank entry in the namespace and database dropdowns which is unable to be selected.