### PR TITLE
Move memory and cpu charts above network charts

### DIFF
--- a/src/screens/surrealist/views/dashboard/DashboardView/index.tsx
+++ b/src/screens/surrealist/views/dashboard/DashboardView/index.tsx
@@ -417,18 +417,6 @@ export function DashboardView() {
 						cols={2}
 						spacing="xl"
 					>
-						<NetworkIngressChart
-							metrics={networkIngressMetrics}
-							duration={metricsDuration}
-							nodeFilter={metricsNodeFilter}
-							isLoading={networkIngressMetricsPending}
-						/>
-						<NetworkEgressChart
-							metrics={networkEgressMetrics}
-							duration={metricsDuration}
-							nodeFilter={metricsNodeFilter}
-							isLoading={networkEgressMetricsPending}
-						/>
 						<MemoryUsageChart
 							metrics={memoryMetrics}
 							duration={metricsDuration}
@@ -440,6 +428,18 @@ export function DashboardView() {
 							duration={metricsDuration}
 							nodeFilter={metricsNodeFilter}
 							isLoading={cpuMetricsPending}
+						/>
+						<NetworkIngressChart
+							metrics={networkIngressMetrics}
+							duration={metricsDuration}
+							nodeFilter={metricsNodeFilter}
+							isLoading={networkIngressMetricsPending}
+						/>
+						<NetworkEgressChart
+							metrics={networkEgressMetrics}
+							duration={metricsDuration}
+							nodeFilter={metricsNodeFilter}
+							isLoading={networkEgressMetricsPending}
 						/>
 					</SimpleGrid>
 


### PR DESCRIPTION
This PR makes a small change to the metrics charts, in which the memory and compute charts are moved above the network charts.