### PR TITLE
Fix compute usage chart showing blank data

### DIFF
--- a/src/screens/surrealist/views/dashboard/ComputeUsageChart/index.tsx
+++ b/src/screens/surrealist/views/dashboard/ComputeUsageChart/index.tsx
@@ -43,7 +43,7 @@ export function ComputeUsageChart({
 			const data = metric.values[i];
 
 			if (data !== null) {
-				value[metric.labels] = data.toFixed(2);
+				value[metric.labels] = Math.round(data * 100) / 100;
 			}
 		}
 


### PR DESCRIPTION
This PR fixes a bug with the compute usage chart where it would show blank data if the amount was below 0.01