### PR TITLE
change: import error title

### DIFF
--- a/src/components/App/modals/data-import.tsx
+++ b/src/components/App/modals/data-import.tsx
@@ -54,8 +54,8 @@ const SqlImportForm = ({ isImporting, confirmImport }: SqlImportFormProps) => {
 			if (failed.length > 0) {
 				for (const fail of failed) {
 					showErrorNotification({
-						title: "Import failed",
-						content: new Error(fail.result),
+						title: "Query partially failed",
+						content: new Error(fail.result)
 					});
 				}
 				return;
@@ -156,9 +156,9 @@ const extractColumnNames = (importedRows: any[], withHeader: boolean) => {
 const extractColumnType = (importedRows: any[], index: number, withHeader: boolean) => {
 	const values = withHeader
 		? importedRows.map((row: any) => {
-				const key = Object.keys(importedRows?.[0] ?? {})[index];
-				return row?.[key];
-			})
+			const key = Object.keys(importedRows?.[0] ?? {})[index];
+			return row?.[key];
+		})
 		: (importedRows as unknown[][]).map((row) => row[index]);
 
 	const uniqueTypes = unique(values.map(extractSurrealType)).filter((t) => t !== "null");
@@ -308,7 +308,7 @@ const completeBatchImport = async (
 			});
 		} else {
 			showErrorNotification({
-				title: "Import failed",
+				title: "Import failed at 2",
 				content: `Failed to insert ${errorImportCount} records. Error: ${errorMessage}`,
 			});
 		}
@@ -646,7 +646,7 @@ const CsvImportForm = ({
 							const err = row.errors[0].message;
 
 							showErrorNotification({
-								title: "Import failed",
+								title: "Import failed at 3",
 								content: `There was an error importing the CSV file: ${err}`,
 							});
 
@@ -687,7 +687,7 @@ const CsvImportForm = ({
 								const err = results.errors[0];
 
 								showErrorNotification({
-									title: "Import failed",
+									title: "Import failed at 4",
 									content: err,
 								});
 
@@ -1090,7 +1090,7 @@ export function DataImportModal() {
 				await executeTransformAndImport(content);
 			} catch (err: any) {
 				showErrorNotification({
-					title: "Import failed",
+					title: "Import failed at 5",
 					content: err,
 				});
 			} finally {

--- a/src/util/errors.tsx
+++ b/src/util/errors.tsx
@@ -11,7 +11,7 @@ import { iconBug, iconWarning } from "./icons";
 /**
  * Thrown during a failure in a cloud operation.
  */
-export class CloudError extends Error {}
+export class CloudError extends Error { }
 
 /**
  * Opens a modal displaying an error message with optional details.
@@ -26,6 +26,10 @@ export async function openErrorModal(
 	message?: string,
 	cause?: string,
 	trace?: string,
+	additionalInfo?: {
+		title: string,
+		content: string
+	}[]
 ) {
 	return new Promise<void>((resolve) => {
 		openModal({
@@ -47,6 +51,17 @@ export async function openErrorModal(
 			),
 			children: (
 				<Stack gap="lg">
+					{additionalInfo && (
+						<Stack gap="lg">
+							{additionalInfo.map((info) => (
+								<Box key={info.title}>
+									<Title order={3}>{info.title}</Title>
+									<CodePreview value={info.content} withCopy />
+								</Box>
+							))}
+						</Stack>
+					)}
+
 					{message && (
 						<Box>
 							<Title order={3}>Message</Title>

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -60,7 +60,7 @@ export const ON_FOCUS_SELECT = (e: FocusEvent<HTMLElement>) => {
  * @param title The title message
  * @param subtitle The subtitle message
  */
-export function showErrorNotification(info: { title: ReactNode; content: any }) {
+export function showErrorNotification(info: { title: ReactNode; content: any; additionalInfo?: { title: string; content: string }[] }) {
 	if (info.content instanceof Error) {
 		showNotification({
 			color: "red",
@@ -76,6 +76,7 @@ export function showErrorNotification(info: { title: ReactNode; content: any }) 
 							info.content.message,
 							info.content.cause,
 							info.content.stack,
+							info.additionalInfo,
 						);
 					}}
 				>


### PR DESCRIPTION
This PR changes the title of the import errors for normal SurrealQL errors. This makes it simpler to identify that the import has not actually failed, but rather the schema provided has a few problems.