### PR TITLE
Misc improvements and changes

### DIFF
--- a/src/cloud/hooks/confirm.tsx
+++ b/src/cloud/hooks/confirm.tsx
@@ -13,6 +13,7 @@ export function useUpdateConfirmation<T>(callback: (value: T) => unknown) {
 		confirmProps: {
 			variant: "gradient",
 		},
+		skippable: true,
 		onConfirm: async (value) => {
 			try {
 				await callback(value);

--- a/src/hooks/cloud.tsx
+++ b/src/hooks/cloud.tsx
@@ -56,6 +56,7 @@ export function usePauseInstance(instance: CloudInstance): () => void {
 		title: `Pause ${instance.name}`,
 		message:
 			"You can pause this instance to temporarily stop all resources and save costs, while data contained in this instance will be preserved.",
+		skippable: true,
 		confirmText: "Pause",
 		confirmProps: {
 			variant: "gradient",
@@ -97,6 +98,7 @@ export function useResumeInstance(instance: CloudInstance): () => void {
 	return useConfirmation({
 		title: `Resume ${instance.name}`,
 		message: "Resume your instance to restore all resources and allow access to your data",
+		skippable: true,
 		confirmText: "Resume",
 		confirmProps: {
 			variant: "gradient",

--- a/src/hooks/updater.tsx
+++ b/src/hooks/updater.tsx
@@ -70,6 +70,7 @@ export function useDesktopUpdater() {
 
 	const promptUpdate = useConfirmation({
 		title: "New major version",
+		skippable: true,
 		message: (
 			<>
 				The update you are about to install is a new major version of Surrealist. Are you

--- a/src/providers/Confirmation/index.tsx
+++ b/src/providers/Confirmation/index.tsx
@@ -1,4 +1,11 @@
-import { type PropsWithChildren, type ReactNode, createContext, useContext, useState } from "react";
+import {
+	type PropsWithChildren,
+	type ReactNode,
+	createContext,
+	useContext,
+	useRef,
+	useState,
+} from "react";
 
 import { Button, type ButtonProps, Divider, Group, Text, TextInput } from "@mantine/core";
 import { Modal } from "@mantine/core";
@@ -8,6 +15,7 @@ import { Spacer } from "~/components/Spacer";
 import { useActiveKeys } from "~/hooks/keys";
 import { useStable } from "~/hooks/stable";
 import { isSimilar } from "~/util/helpers";
+import { useSetting } from "~/hooks/config";
 
 type DynamicNode<T> = ReactNode | ((value: T) => ReactNode);
 
@@ -59,6 +67,8 @@ export function ConfirmationProvider({ children }: PropsWithChildren) {
 	const [value, setValue] = useState<any>();
 
 	const isShifting = useActiveKeys("Shift");
+	const confirmationRef = useRef<HTMLButtonElement>(null);
+	const [enterConfirms] = useSetting("behavior", "enterConfirms");
 
 	const setConfirmation = (value: any, options: ConfirmOptions<any>) => {
 		if (isConfirming) {
@@ -99,6 +109,15 @@ export function ConfirmationProvider({ children }: PropsWithChildren) {
 				title={
 					<PrimaryTitle>{applyNode(options?.title ?? DEFAULT_TITLE, value)}</PrimaryTitle>
 				}
+				onKeyDown={(e) => {
+					if (
+						enterConfirms &&
+						e.key === "Enter" &&
+						(!options?.verification || isVerified)
+					) {
+						confirmationRef.current?.focus();
+					}
+				}}
 			>
 				<Text fz="lg">{applyNode(options?.message, value)}</Text>
 				{options?.verification && (
@@ -133,6 +152,7 @@ export function ConfirmationProvider({ children }: PropsWithChildren) {
 					</Button>
 					<Spacer />
 					<Button
+						ref={confirmationRef}
 						color="red"
 						onClick={onConfirm}
 						disabled={!isVerified}

--- a/src/providers/Confirmation/index.tsx
+++ b/src/providers/Confirmation/index.tsx
@@ -12,10 +12,10 @@ import { Modal } from "@mantine/core";
 import { useInputState } from "@mantine/hooks";
 import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { Spacer } from "~/components/Spacer";
+import { useSetting } from "~/hooks/config";
 import { useActiveKeys } from "~/hooks/keys";
 import { useStable } from "~/hooks/stable";
 import { isSimilar } from "~/util/helpers";
-import { useSetting } from "~/hooks/config";
 
 type DynamicNode<T> = ReactNode | ((value: T) => ReactNode);
 

--- a/src/providers/Designer/drawer.tsx
+++ b/src/providers/Designer/drawer.tsx
@@ -76,6 +76,7 @@ export function DesignDrawer({
 		message:
 			"You are about to remove this table and all data contained within it. This action cannot be undone.",
 		confirmText: "Remove",
+		skippable: true,
 		onConfirm: async () => {
 			onClose(true);
 

--- a/src/providers/Inspector/drawer.tsx
+++ b/src/providers/Inspector/drawer.tsx
@@ -143,6 +143,7 @@ export function InspectorDrawer({ opened, history, onClose, onRefresh }: Inspect
 	const deleteRecord = useConfirmation({
 		message: "You are about to delete this record. This action cannot be undone.",
 		confirmText: "Delete",
+		skippable: true,
 		onConfirm: async () => {
 			await executeQuery(/* surql */ `DELETE ${formatValue(history.current)}`);
 

--- a/src/screens/surrealist/components/DatabaseList/index.tsx
+++ b/src/screens/surrealist/components/DatabaseList/index.tsx
@@ -45,6 +45,7 @@ function Database({ value, activeNamespace, activeDatabase, onOpen, onRemove }: 
 		title: "Remove database",
 		message: `Are you sure you want to remove the database "${value}"?`,
 		confirmText: "Remove",
+		skippable: true,
 		onConfirm: async () => {
 			await executeQuery(/* surql */ `REMOVE DATABASE ${escapeIdent(value)}`);
 

--- a/src/screens/surrealist/components/NamespaceList/index.tsx
+++ b/src/screens/surrealist/components/NamespaceList/index.tsx
@@ -44,6 +44,7 @@ function Namespace({ value, activeNamespace, onOpen, onRemove }: NamespaceProps)
 		title: "Remove namespace",
 		message: `Are you sure you want to remove the namespace "${value}"?`,
 		confirmText: "Remove",
+		skippable: true,
 		onConfirm: async () => {
 			await executeQuery(/* surql */ `REMOVE NAMESPACE ${escapeIdent(value)}`);
 

--- a/src/screens/surrealist/components/TablesPane/index.tsx
+++ b/src/screens/surrealist/components/TablesPane/index.tsx
@@ -97,6 +97,7 @@ export function TablesPane({
 		message:
 			"You are about to remove this table and all data contained within it. This action cannot be undone.",
 		confirmText: "Remove",
+		skippable: true,
 		onConfirm: async (table: string) => {
 			await executeQuery(`REMOVE TABLE ${escapeIdent(table)}`);
 			await syncConnectionSchema({
@@ -112,6 +113,7 @@ export function TablesPane({
 	const clearTable = useConfirmation({
 		message: "You are about to clear all records in this table. This action cannot be undone.",
 		confirmText: "Clear",
+		skippable: true,
 		onConfirm: async (table: string) => {
 			await executeQuery(`DELETE ${escapeIdent(table)}`);
 			RecordsChangedEvent.dispatch(null);

--- a/src/screens/surrealist/pages/OrganizationManage/tabs/team.tsx
+++ b/src/screens/surrealist/pages/OrganizationManage/tabs/team.tsx
@@ -63,6 +63,7 @@ export function OrganizationTeamTab({ organization }: OrganizationTabProps) {
 		title: "Leave organisation",
 		message: `Are you sure you want to leave ${organization.name}?`,
 		confirmText: "Leave",
+		skippable: true,
 		onConfirm: async () => {
 			navigate("/organisations");
 

--- a/src/screens/surrealist/pages/OrganizationManage/tabs/team.tsx
+++ b/src/screens/surrealist/pages/OrganizationManage/tabs/team.tsx
@@ -55,6 +55,7 @@ export function OrganizationTeamTab({ organization }: OrganizationTabProps) {
 
 	const requestRemove = useConfirmation<CloudMember>({
 		title: "Remove member",
+		skippable: true,
 		message: (member) => `Are you sure you want to remove ${member.name}?`,
 		onConfirm: (value) => removeMutation.mutate(value.user_id),
 	});

--- a/src/screens/surrealist/pages/Organizations/organization.tsx
+++ b/src/screens/surrealist/pages/Organizations/organization.tsx
@@ -67,6 +67,7 @@ export function OrganizationTile({
 		title: "Leave organisation",
 		message: "Are you sure you want to leave this organisation?",
 		confirmText: "Leave",
+		skippable: true,
 		onConfirm: async () => {
 			await removeMutation.mutateAsync(userId);
 

--- a/src/screens/surrealist/views/authentication/LevelPanel/index.tsx
+++ b/src/screens/surrealist/views/authentication/LevelPanel/index.tsx
@@ -73,6 +73,7 @@ export function LevelPanel({ level, icon, color, disabled, users, accesses }: Le
 	const removeUser = useConfirmation<SchemaUser>({
 		title: "Remove system user",
 		message: `This will remove the user from ${level.toLocaleLowerCase()} authentication and reject any future sign-in attempts. Are you sure?`,
+		skippable: true,
 		onConfirm: async (value) => {
 			await executeQuery(`REMOVE USER ${escapeIdent(value.name)} ON ${level}`);
 			await syncConnectionSchema();
@@ -82,6 +83,7 @@ export function LevelPanel({ level, icon, color, disabled, users, accesses }: Le
 	const removeAccess = useConfirmation<SchemaAccess>({
 		title: "Remove access method",
 		message: `This will remove the access method from ${level.toLocaleLowerCase()} authentication and prevent any future sign-in attempts using this method. Are you sure?`,
+		skippable: true,
 		onConfirm: async (value) => {
 			await executeQuery(`REMOVE ACCESS ${escapeIdent(value.name)} ON ${level}`);
 			await syncConnectionSchema();

--- a/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
+++ b/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
@@ -453,6 +453,7 @@ export function ExplorerPane({ activeTable, onCreateRecord }: ExplorerPaneProps)
 					}}
 				>
 					<DataTable
+						schema={schema}
 						data={records}
 						sorting={sortMode}
 						selected={selected}

--- a/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
+++ b/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
@@ -164,6 +164,7 @@ export function ExplorerPane({ activeTable, onCreateRecord }: ExplorerPaneProps)
 
 	const removeRecord = useConfirmation<RecordId>({
 		title: "Delete record",
+		skippable: true,
 		message: (value) => (
 			<Box>
 				Are you sure you want to delete this record?

--- a/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
+++ b/src/screens/surrealist/views/explorer/ExplorerPane/index.tsx
@@ -183,6 +183,7 @@ export function ExplorerPane({ activeTable, onCreateRecord }: ExplorerPaneProps)
 	const removeSelectedRecords = useConfirmation({
 		title: "Bulk delete records",
 		message: `Are you sure you want to delete all ${selected.size} records?`,
+		skippable: true,
 		onConfirm: async () => {
 			const selectedRecords = Array.from(selected).map((it) => new StringRecordId(it));
 

--- a/src/screens/surrealist/views/functions/FunctionsView/index.tsx
+++ b/src/screens/surrealist/views/functions/FunctionsView/index.tsx
@@ -195,6 +195,7 @@ export function FunctionsView() {
 	const removeFunction = useConfirmation({
 		message: "You are about to remove this function. This action cannot be undone.",
 		confirmText: "Remove",
+		skippable: true,
 		onConfirm: async (func: FunctionDetails) => {
 			await executeQuery(`REMOVE FUNCTION fn::${func.details.name}`);
 			await syncConnectionSchema();

--- a/src/screens/surrealist/views/parameters/ParametersView/index.tsx
+++ b/src/screens/surrealist/views/parameters/ParametersView/index.tsx
@@ -140,6 +140,7 @@ export function ParametersView() {
 	const removeParameter = useConfirmation({
 		message: "You are about to remove this parameter. This action cannot be undone.",
 		confirmText: "Remove",
+		skippable: true,
 		onConfirm: async (name: string) => {
 			await executeQuery(`REMOVE PARAM $${name}`);
 			await syncConnectionSchema();

--- a/src/screens/surrealist/views/query/QueryPane/index.tsx
+++ b/src/screens/surrealist/views/query/QueryPane/index.tsx
@@ -27,7 +27,7 @@ import { Button, Group, HoverCard, Paper, ThemeIcon, Transition, rem } from "@ma
 import { Text } from "@mantine/core";
 import { surrealql } from "@surrealdb/codemirror";
 import { objectify, trim } from "radash";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { type HtmlPortalNode, OutPortal } from "react-reverse-portal";
 import { ActionButton } from "~/components/ActionButton";
 import { CodeEditor, StateSnapshot } from "~/components/CodeEditor";
@@ -91,8 +91,9 @@ export function QueryPane({
 	const surqlVersion = useDatabaseVersionLinter(editor);
 	const queryStateMap = useQueryStore((s) => s.queryState);
 	const saveTasks = useRef<Map<string, any>>(new Map());
+	const [executionHidden, setExecutionHidden] = useState(false);
 	const [allowSelectionExecution] = useSetting("behavior", "querySelectionExecution");
-	const [showSelectionExecutionWarning, setShowSelectionExecutionWarning] = useSetting(
+	const [showSelectionExecutionWarning] = useSetting(
 		"behavior",
 		"querySelectionExecutionWarning",
 	);
@@ -200,10 +201,6 @@ export function QueryPane({
 	});
 
 	const hasSelection = selection?.empty === false;
-
-	const handleHideSelectionWarning = useStable(() => {
-		setShowSelectionExecutionWarning(false);
-	});
 
 	const extensions = useMemo(
 		() => [
@@ -324,7 +321,12 @@ export function QueryPane({
 			/>
 			<Transition
 				transition="slide-up"
-				mounted={showSelectionExecutionWarning && allowSelectionExecution && hasSelection}
+				mounted={
+					showSelectionExecutionWarning &&
+					allowSelectionExecution &&
+					hasSelection &&
+					!executionHidden
+				}
 			>
 				{(style) => (
 					<Paper
@@ -343,6 +345,7 @@ export function QueryPane({
 							bottom: rem(12),
 							left: rem(12),
 							right: rem(12),
+							zIndex: 1,
 						}}
 					>
 						<Group>
@@ -353,9 +356,9 @@ export function QueryPane({
 								size="compact-sm"
 								variant="subtle"
 								color="violet"
-								onClick={handleHideSelectionWarning}
+								onClick={() => setExecutionHidden(true)}
 							>
-								Hide
+								Hide Temporarily
 							</Button>
 							<Button
 								size="compact-sm"

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -179,6 +179,7 @@ export interface SurrealistBehaviorSettings {
 	tableSuggest: boolean;
 	variableSuggest: boolean;
 	queryErrorChecker: boolean;
+	enterConfirms: boolean;
 	querySelectionExecution: boolean;
 	querySelectionExecutionWarning: boolean;
 	windowPinned: boolean;

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -41,6 +41,7 @@ export function createBaseSettings(): SurrealistSettings {
 			tableSuggest: true,
 			variableSuggest: true,
 			queryErrorChecker: true,
+			enterConfirms: false,
 			querySelectionExecution: true,
 			querySelectionExecutionWarning: true,
 			windowPinned: false,

--- a/src/util/preferences.tsx
+++ b/src/util/preferences.tsx
@@ -176,6 +176,23 @@ export function useComputedPreferences(): PreferenceSection[] {
 				],
 			},
 			{
+				id: "behavior",
+				name: "Behavior",
+				preferences: [
+					{
+						id: "enter-confirms",
+						name: "Enter to confirm",
+						description: "Use enter to confirm actions in confirmation modals",
+						controller: new CheckboxController({
+							reader: (config) => config.settings.behavior.enterConfirms,
+							writer: (config, value) => {
+								config.settings.behavior.enterConfirms = value;
+							},
+						}),
+					},
+				],
+			},
+			{
 				id: "connection",
 				name: "Connection",
 				preferences: [


### PR DESCRIPTION
This PR adds several improvements:
- Makes the query execution warning able to be hidden temporarily (until view refresh)
- Makes confirmations skippable (except for some specific ones that are extra important)
- Add an indexed icon to the explorer view columns to show which columns are indexed
- Add a preference to use enter to confirm in modals

Closes #799
Closes #797