### PR TITLE
Fix: Allow users to select error text

### DIFF
--- a/src/screens/surrealist/views/query/ResultPane/previews/graph.tsx
+++ b/src/screens/surrealist/views/query/ResultPane/previews/graph.tsx
@@ -783,7 +783,7 @@ export function GraphPreview({ responses, selected }: PreviewProps) {
 			fz={textSize}
 			c="red"
 			ff="mono"
-			style={{ whiteSpace: "pre-wrap" }}
+			style={{ whiteSpace: "pre-wrap", userSelect: "text" }}
 		>
 			{result}
 		</Text>

--- a/src/screens/surrealist/views/query/ResultPane/previews/individual.tsx
+++ b/src/screens/surrealist/views/query/ResultPane/previews/individual.tsx
@@ -31,7 +31,7 @@ export function IndividualPreview({ responses, selected }: PreviewProps) {
 			fz={textSize}
 			c="red"
 			ff="mono"
-			style={{ whiteSpace: "pre-wrap" }}
+			style={{ whiteSpace: "pre-wrap", userSelect: "text" }}
 		>
 			{result}
 		</Text>

--- a/src/screens/surrealist/views/query/ResultPane/previews/table.tsx
+++ b/src/screens/surrealist/views/query/ResultPane/previews/table.tsx
@@ -72,7 +72,7 @@ export function TablePreview({ responses, selected }: PreviewProps) {
 			fz={textSize}
 			c="red"
 			ff="mono"
-			style={{ whiteSpace: "pre-wrap" }}
+			style={{ whiteSpace: "pre-wrap", userSelect: "text" }}
 		>
 			{result}
 		</Text>


### PR DESCRIPTION
Closes #955 - Bug: Unable to select/copy text when result is an error