### PR TITLE
Fix use of all regions instead of supported regions in cloud

### DIFF
--- a/src/screens/surrealist/pages/OrganizationDeploy/sections/instance.tsx
+++ b/src/screens/surrealist/pages/OrganizationDeploy/sections/instance.tsx
@@ -11,11 +11,11 @@ import { iconCheck } from "~/util/icons";
 import { DeploySectionProps } from "../types";
 export function DeploymentSection({ organisation, details, setDetails }: DeploySectionProps) {
 	const versions = useAvailableInstanceVersions();
-	const regions = useCloudStore((s) => s.regions);
+	const allRegions = useCloudStore((s) => s.regions);
 	const regionSet = new Set(organisation?.plan.regions ?? []);
-	const supportedRegions = regions.filter((region) => regionSet.has(region.slug));
+	const supportedRegions = allRegions.filter((region) => regionSet.has(region.slug));
 
-	const regionList = regions.map((region) => ({
+	const regionList = supportedRegions.map((region) => ({
 		value: region.slug,
 		label: region.description,
 	}));


### PR DESCRIPTION
Fixes a problem where organisations could select any region to deploy instead of the regions they had access to, resulting in an error on deployment.